### PR TITLE
Grunt changes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -602,10 +602,14 @@ module.exports = function (grunt) {
         'copy:dev',
         'copy:config',
         'copy:build-search',
-        'build-config',
+        'build-config'
+    ]);
+
+    grunt.registerTask('dist', [
+        'build',
         'requirejs',
         'filerev',
-        'regex-replace',
+        'regex-replace'
     ]);
 
     grunt.registerTask('deploy', [

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ init:
 # deals with filling out templated URL targets based on deployment
 # location (prod vs. next vs. CI vs. local)
 build:
-	@ grunt build
+	@ grunt dist
 	@ node tools/process_config.js $(DEPLOY_CFG)
 
 # The deployment step uses grunt to, essentially, copy the build

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-  "name": "Thrift Test",
+  "name": "KBase UI",
   "version": "0.0.1",
-  "main": "path/to/main.css",
+  "main": "none",
   "ignore": [
     ".jshintrc",
     "**/*.txt"
@@ -37,7 +37,6 @@
     "kbase-common-js": "kbase/kbase-common-js#master",
     "kbase-ui-plugin-dataview": "kbase/kbase-ui-plugin-dataview#master",
     "kbase-ui-plugin-dashboard": "kbase/kbase-ui-plugin-dashboard#master",
-    "kbase-ui-plugin-typeview": "eapearson/kbase-ui-plugin-typeview#master",
     "kbase-service-clients-js": "eapearson/kbase-service-clients-js#master",
     "kbase-ui-plugin-vis-widgets": "eapearson/kbase-ui-plugin-vis-widgets#master",
     "kbase-ui-plugin-databrowser": "eapearson/kbase-ui-plugin-databrowser#master",
@@ -47,7 +46,8 @@
     "moment": "2.10.6",
     "numeral": "1.5.3",
     "blockUI": "jquery.blockUI#*",
-    "q": "2.0.2"
+    "q": "2.0.2",
+    "kbase-ui-plugin-typeview": "eapearson/kbase-ui-plugin-typeview#master"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Reverted `grunt build` to just prepare the build directory. Added `grunt dist` that builds the distribution (concats, minifies, rewrites index.html).

You should only run one or the other. `grunt dist` contains the build command as well.

Also updated the Makefile to match.
