### PR TITLE
This is just until the bluebird warnings are coded out of existence.

### DIFF
--- a/src/client/js/main.js
+++ b/src/client/js/main.js
@@ -1,6 +1,7 @@
 /*global define*/
 /*jslint white: true*/
 define([
+    'bluebird',
     'app',
     'kb_common_dom',
     'yaml!ui.yml',
@@ -10,8 +11,12 @@ define([
     // 'css!kb_icons',
     'css!kb_ui',
     'css!kb_datatables'
-], function (App, dom, uiConfig) {
+], function (Promise, App, dom, uiConfig) {
     'use strict';
+    Promise.config({
+        warnings: false,
+        longStackTraces: true
+    });
     function makeSymbol(s) {
         return s.trim(' ').replace(/ /, '_');
     }
@@ -33,7 +38,7 @@ define([
         dom.qs('#error').style.display = 'block';
     }
     displayStatus('running');
-    
+
     return {
         start: function () {
             return App.run({
@@ -76,7 +81,7 @@ define([
                     });
                     runtime.send('ui', 'addButton', {
                         label: 'Apple',
-                        icon: 'apple', 
+                        icon: 'apple',
                         external: true,
                         callback: function () {
                             alert('Hi, from Apple');


### PR DESCRIPTION
It ends up that bluebird appears to be build in develop mode, or at least the way we are including it. Perhaps the non-minified version is generated with debugging on. In any case, it uses the development settings, which includes emitting warnings. Configuring it early in the page load process (main.js) quiets it  down. I'll look to see (a) how to ensure that we are including a production version and (b) whether it is easily switchable (because during development indeed it would be good to get these warnings.) 
It is easy enough to switch that in our code via the Promise.config(), but there may be other implications of developer mode (but after a quick perusal I don't think so  -- e.g. the library is not built differently). 
So I think a kbase config for develop / production mode which is reflected in the bluebird settings but also could be handy for us as well.