### PR TITLE
Fixed search dependencies and loading.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -274,6 +274,7 @@ module.exports = function (grunt) {
 //        },
 
         // Dependencies needed for Search (for now)
+        // PLEASE STOP DELETING THESE.
         {
             name: 'blockUI',
             src: ['jquery.blockUI.js']
@@ -281,7 +282,13 @@ module.exports = function (grunt) {
         {
             name: 'q',
             src: ['q.js']
+        },
+        {
+            dir: 'postal.js',
+            cwd: 'lib',
+            name: 'postal'
         }
+        // End Search Dependencies.
 
 
     ],

--- a/bower.json
+++ b/bower.json
@@ -46,8 +46,9 @@
     "moment": "2.10.6",
     "numeral": "1.5.3",
     "blockUI": "jquery.blockUI#*",
-    "q": "2.0.2",
-    "kbase-ui-plugin-typeview": "eapearson/kbase-ui-plugin-typeview#master"
+    "q": "~1.4.1",
+    "kbase-ui-plugin-typeview": "eapearson/kbase-ui-plugin-typeview#master",
+    "postal.js": "~1.0.7"
   },
   "devDependencies": {}
 }

--- a/src/search/index.html
+++ b/src/search/index.html
@@ -9,7 +9,7 @@
    <link rel="stylesheet" type="text/css" href="../bower_components/bootstrap/css/bootstrap.min.css" />
 
    <!-- jquery-ui-1.10.0.custom.css is needed for the landing page card layout, some old landing pages still use this style -->
-   <link rel="stylesheet" type="text/css" href="../bower_components/jquery-ui/themes/ui-lightness/jquery-ui.min.css" />
+   <!-- <link rel="stylesheet" type="text/css" href="../bower_components/jquery-ui/themes/ui-lightness/jquery-ui.min.css" /> -->
 
    <!-- DataTable 1.10.4 css dependencies. 2014-01-29 eap -->
    <!-- <link rel="stylesheet" type="text/css" href="assets/css/dataTables.bootstrap.css" /> -->
@@ -91,7 +91,7 @@
 
    <script src="../bower_components/jquery/jquery.js"></script>
    <!-- <script src="../ext/jquery-migrate/jquery-migrate-1.2.1.js"></script> -->
-   <script src="../bower_components/jquery-ui/jquery-ui.js"></script>
+   <!-- <script src="../bower_components/jquery-ui/jquery-ui.js"></script> -->
    <script src="../bower_components/blockUI/jquery.blockUI.js"></script>
    <script src="../bower_components/bootstrap/js/bootstrap.min.js"></script>
    <script src="../bower_components/d3/d3.js"></script>


### PR DESCRIPTION
Search needs to have the following:
q 1.4.1
postal.js 1.0.7
jquery.blockUI (any version)

That'll go away eventually (these are mainly for the navbar and such, because it's a separate page taken directly from ui-common), but they're needed for now.