### PR TITLE
Fixed require paths in the narrative loading page.

### DIFF
--- a/src/client/loading.html
+++ b/src/client/loading.html
@@ -4,7 +4,7 @@
         <title>KBase Narrative Interface</title>
         <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <script src="/modules/bower_components/requirejs/require.js"></script>
-        <script src="/require-config.js"></script>
+        <script src="/modules/require-config.js"></script>
     </head>
     <body>
         <div style="text-align:center;">


### PR DESCRIPTION
The path to the require-config.js was broken, so it would just sit and spin on the "Getting you a new narrative..." page.