### PR TITLE
Updated narrativeManager to make narratives of the right TO version.

### DIFF
--- a/src/client/modules/plugins/narrativemanager/modules/narrativeManager.js
+++ b/src/client/modules/plugins/narrativemanager/modules/narrativeManager.js
@@ -313,12 +313,9 @@ define([
                         cellData = gatherCellData(cells, specMapping, parameters),
                             narrativeObject = {
                                 nbformat_minor: 0,
-                                worksheets: [{
-                                        cells: cellData,
-                                        metadata: {}
-                                    }],
+                                cells: cellData,
                                 metadata: metadata,
-                                nbformat: 3
+                                nbformat: 4
                             },
                         // setup external string to string metadata for the WS object
                         metadataExternal = {};


### PR DESCRIPTION
This was working before, because the updated typed object module was unreleased. Now it's been released (to deal with another problem), which caused creating new narratives to break.