### PR TITLE
Updated dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "spark-md5": "2.0.0",
-        "bluebird": "3.0.6",
+        "bluebird": "3.1.5",
         "comma-separated-values": "3.6.3",
         "d3": "3.5.6",
         "jquery": "2.1.4",

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -91,7 +91,7 @@ plugins:
     -
         name: dataapidemo
         globalName: kbase-ui-plugin-data-api-demo
-        version: 0.1.3
+        version: 0.1.4
         cwd: src/plugin
         source:
             bower: {}
@@ -134,6 +134,6 @@ modules:
             bower: {}
     -
         globalName: kbase-data-api-client-js
-        version: 0.1.9
+        version: 0.1.10
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -75,6 +75,6 @@ modules:
             bower: {}
     -
         globalName: kbase-data-api-client-js
-        version: 0.1.9
+        version: 0.1.10
         source:
             bower: {}


### PR DESCRIPTION
data api - to 0.1.10 to catch the up with merging and bug fixes
data api demo (to match) - in dev build, updated to work with 0.1.10 data api
bluebird - updated to latest stable build 3.1.5 (3.2.0 was bad, 3.2.1 may be ok but holding off for now)