### PR TITLE
update to dataview which fixes the objgraph path

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -41,7 +41,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.0.2
+        version: 1.0.3
         cwd: src/plugin
         source:
             bower: {}
@@ -124,7 +124,7 @@ modules:
             bower: {}
     -
         globalName: kbase-common-js
-        version: 1.0.0
+        version: 1.1.0
         source:
             bower: {}
     -

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -38,7 +38,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.0.2
+        version: 1.0.3
         cwd: src/plugin
         source:
             bower: {}
@@ -71,7 +71,7 @@ modules:
             bower: {}
     -
         globalName: kbase-common-js
-        version: 1.0.0
+        version: 1.1.0
         source:
             bower: {}
     -


### PR DESCRIPTION
Links from the provenance button in the narrative were broken because they point to #objgraph, which had been renamed to #provenance. That route now supports both pathways. This change is in the dataview plugin, and imported into kbase-ui
Simultaneously, in support of easier path specification in the plugin config, the little router in common js supports multiple matches for path literal, as well as optional parameters at the end of the path. brought in through the common js module.
