### PR TITLE
Catalog module viewer typo fix in require

### DIFF
--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleViewer.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleViewer.js
@@ -12,7 +12,7 @@ define([
     'kb/service/client/catalog',
     './catalog_util',
     './app_card',
-    'catalog_registration',
+    'catalog_registration_widget',
     'kb/widget/legacy/authenticatedWidget',
     'bootstrap'
 ],


### PR DESCRIPTION
The module page was broken for owners of the module because the registration widget dependency was not properly included.