### PR TITLE
Added basic catalog stats page

### DIFF
--- a/src/client/modules/plugins/catalog/config.yml
+++ b/src/client/modules/plugins/catalog/config.yml
@@ -33,6 +33,9 @@ source:
         -
             module: catalog_admin
             file: catalog_admin
+        -
+            module: catalog_stats
+            file: catalog_stats
         - 
             module: app_card
             file: app_card
@@ -59,6 +62,9 @@ source:
         -
             module: catalog_admin_widget
             file: widgets/kbaseCatalogAdmin
+        -
+            module: catalog_stats_widget
+            file: widgets/kbaseCatalogStats
         -
             module: catalog_view_sdk_registration_log_widget
             file: widgets/kbaseViewSDKRegistrationLog
@@ -96,6 +102,10 @@ install:
         - 
             module: catalog_admin
             id: catalog_admin
+            type: factory
+        - 
+            module: catalog_stats
+            id: catalog_stats
             type: factory
         - 
             module: catalog_util
@@ -155,6 +165,13 @@ install:
                 jqueryName: KBaseCatalogAdmin
             type: kbwidget
         -
+            module: catalog_stats_widget
+            id: catalog_stats_widget
+            title: App Catalog Stats
+            config:
+                jqueryName: KBaseCatalogStats
+            type: kbwidget
+        -
             module: catalog_view_sdk_registration_log_widget
             id: catalog_view_sdk_registration_log_widget
             title: App Catalog Module Registration Log
@@ -202,6 +219,9 @@ install:
         -
             path: ['appcatalog', 'admin']
             widget: catalog_admin
+        -
+            path: ['appcatalog', 'stats']
+            widget: catalog_stats
     menus:
         -
             name: appcatalog

--- a/src/client/modules/plugins/catalog/modules/catalog_stats.js
+++ b/src/client/modules/plugins/catalog/modules/catalog_stats.js
@@ -1,0 +1,99 @@
+/*global
+ define
+ */
+/*jslint
+ browser: true,
+ white: true
+ */
+define([
+    'bluebird',
+    'kb/common/dom',
+    'kb/common/html',
+    'kb/widget/widgetSet'
+], function (Promise, DOM, html, WidgetSet) {
+    'use strict';
+    function widget(config) {
+        var mount, container, runtime = config.runtime,
+            widgetSet = WidgetSet.make({runtime: runtime}),
+            layout;
+
+        // Mini widget manager
+        // TODO: the jquery name should be stored in the widget definition not here.
+        function render() {
+
+            // the catalog home page is simple the catalog browser
+            var div=html.tag('div');
+            return div({
+                id: widgetSet.addWidget('catalog_stats_widget', 
+                    {
+                        jqueryName: 'KBaseCatalogStats', 
+                        jquery_name:'KBaseCatalogStats'
+                    })
+            });
+        }
+
+        layout = render();
+
+        // Widget Interface Implementation
+
+        function init(config) {
+            return Promise.try(function () {
+                return widgetSet.init(config);
+            });
+        }
+        function attach(node) {
+            runtime.send('ui', 'setTitle', 'App Catalog');
+            return Promise.try(function () {
+                mount = node;
+                container = mount.appendChild(DOM.createElement('div'));
+                container.innerHTML = layout;
+                // mount.appendChild(container);
+                return widgetSet.attach();
+            });
+        }
+        function start(params) {
+            return Promise.try(function () {
+                return widgetSet.start(params);
+            });
+        }
+        function run(params) {
+            return Promise.try(function () {
+                return widgetSet.run(params);
+            });
+        }
+        function stop() {
+            return Promise.try(function () {
+                return widgetSet.stop();
+            });
+        }
+        function detach() {
+            runtime.send('ui', 'setTitle', '');
+            return Promise.try(function () {
+                return widgetSet.detach();
+            });
+        }
+        function destroy() {
+            return Promise.try(function () {
+                return widgetSet.destroy();
+            });
+        }
+
+        // Widget Interface
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run,
+            stop: stop,
+            detach: detach,
+            destroy: destroy
+        };
+    }
+
+    return {
+        make: function (config) {
+            return widget(config);
+        }
+    };
+
+});

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
@@ -1,0 +1,207 @@
+/*global
+ define
+ */
+/*jslint
+ browser: true,
+ white: true
+ */
+
+
+
+define([
+    'jquery',
+    'kb/service/client/narrativeMethodStore',
+    'kb/service/client/catalog',
+    './catalog_util',
+    'datatables',
+    'kb/widget/legacy/authenticatedWidget',
+    'bootstrap',
+    'datatables_bootstrap',
+],
+    function ($, NarrativeMethodStore, Catalog, CatalogUtil) {
+        $.KBWidget({
+            name: "KBaseCatalogStats",
+            parent: "kbaseAuthenticatedWidget",  // todo: do we still need th
+            options: {
+            },
+
+            // clients to the catalog service and the NarrativeMethodStore
+            catalog: null,
+            util: null,
+
+            // main panel and elements
+            $mainPanel: null,
+            $loadingPanel: null,
+            $basicStatsDiv: null,
+
+            allStats: null,
+
+            init: function (options) {
+                this._super(options);
+                
+                var self = this;
+
+                // new style we have a runtime object that gives us everything in the options
+                self.runtime = options.runtime;
+                self.setupClients();
+                self.util = new CatalogUtil();
+
+                // initialize and add the main panel
+                self.$loadingPanel = self.initLoadingPanel();
+                self.$elem.append(self.$loadingPanel);
+                var mainPanelElements = self.initMainPanel();
+                self.$mainPanel = mainPanelElements[0];
+                self.$basicStatsDiv = mainPanelElements[1];
+                self.$elem.append(self.$mainPanel);
+                self.showLoading();
+
+                // get the module information
+                var loadingCalls = [];
+                loadingCalls.push(self.getStats());
+
+                // when we have it all, then render the list
+                Promise.all(loadingCalls).then(function() {
+                    self.render();
+                    self.hideLoading();
+                });
+
+                return this;
+            },
+
+            render: function() {
+                var self = this;
+
+                var $table = $('<table>').addClass('table');
+
+
+                var $container = $('<div>').addClass('container')
+                        .append($('<div>').addClass('row')
+                            .append($('<div>').addClass('col-md-12')
+                                .append($table)));
+
+                var tblSettings = {
+                    "bFilter": true,
+                    "sPaginationType": "full_numbers",
+                    "iDisplayLength": 100,
+                    "sDom": 'ft<ip>',
+                    "aaSorting": [[ 2, "dsc" ], [1, "asc"]],
+                    "columns": [
+                        {sTitle: "ID", data: "id"},
+                        {sTitle: "Module", data: "module"},
+                        {sTitle: "Total Runs", data: "nCalls"},
+                        {sTitle: "Errors", data: "nErrors"},
+                        {sTitle: "Success %", data: "success"},
+                        {sTitle: "Avg Run Time", data: "meanRunTime"},
+                        {sTitle: "Avg Queue Time", data: "meanQueueTime"},
+                        {sTitle: "Total Run Time", data: "totalRunTime"}
+                    ],
+                    "data": self.allStats
+                };
+                $table.DataTable(tblSettings);
+
+                self.$basicStatsDiv.append($container);
+
+            },
+
+
+            setupClients: function() {
+                this.catalog = new Catalog(
+                    this.runtime.getConfig('services.catalog.url'),
+                    { token: this.runtime.service('session').getAuthToken() }
+                );
+            },
+
+            initMainPanel: function($appListPanel, $moduleListPanel) {
+                var $mainPanel = $('<div>').addClass('container');
+
+                $mainPanel.append($('<div>').addClass('kbcb-back-link')
+                        .append($('<a href="#appcatalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+
+                var $basicStatsDiv = $('<div>');
+                $mainPanel.append($basicStatsDiv);
+
+                $mainPanel.append('<br><br>');
+
+                return [$mainPanel, $basicStatsDiv];
+            },
+
+            initLoadingPanel: function() {
+                var $loadingPanel = $('<div>').addClass('kbcb-loading-panel-div');
+                $loadingPanel.append($('<i>').addClass('fa fa-spinner fa-2x fa-spin'));
+                return $loadingPanel;
+            },
+
+            showLoading: function() {
+                var self = this;
+                self.$loadingPanel.show();
+                self.$mainPanel.hide();
+            },
+            hideLoading: function() {
+                var self = this;
+                self.$loadingPanel.hide();
+                self.$mainPanel.show();
+            },
+
+            getNiceDuration: function(seconds) {
+                var hours = Math.floor(seconds / 3600);
+                seconds = seconds - (hours * 3600);
+                var minutes = Math.floor(seconds / 60);
+                seconds = seconds - (minutes * 60);
+
+                var duration = '';
+                if(hours>0) {
+                    duration = hours + 'h '+ minutes + 'm';
+                } else if (minutes>0) {
+                    duration = minutes + 'm ' + Math.round(seconds) + 's'; 
+                }
+                else {
+                    duration = (Math.round(seconds*100)/100) + 's'; 
+                }
+                return duration;
+
+            },
+
+
+            getStats: function() {
+                var self = this
+
+                return self.catalog.get_exec_aggr_stats({})
+                    .then(function (stats) {
+                        self.allStats = [];
+
+                        for(var k=0; k<stats.length; k++) {
+                            var s = stats[k];
+
+                            var id = s.full_app_id;
+                            if(s.full_app_id.split('/').length==2) {
+                                id = s.full_app_id.split('/')[1];
+                            }
+
+                            var goodCalls = s.number_of_calls - s.number_of_errors
+                            var successPercent = ((goodCalls) / s.number_of_calls)*100;
+
+                            var stat = {
+                                id: '<a href="#appcatalog/app/'+s.full_app_id+'/dev">'+id+'</a>',
+                                module: '<a href="#appcatalog/module/'+s.module_name+'">'+s.module_name+'</a>',
+                                nCalls: s.number_of_calls,
+                                nErrors: s.number_of_errors,
+                                success: successPercent.toPrecision(3),
+                                meanRunTime:  self.getNiceDuration(s.total_exec_time/s.number_of_calls),
+                                meanQueueTime: self.getNiceDuration(s.total_queue_time/s.number_of_calls),
+                                totalRunTime: self.getNiceDuration(s.total_exec_time),
+                            }
+                            self.allStats.push(stat);
+                        }
+
+                        console.log(stats);
+                    })
+                    .catch(function (err) {
+                        console.error('ERROR');
+                        console.error(err);
+                    });
+            }
+        });
+    });
+
+
+


### PR DESCRIPTION
Gives a basic summary of the run statistics.  Available under: #appcatalog/stats

I didn't quite get the sorting by run times properly working (it is sorting by strings rather than values, and I'll need to investigate further with datatables), but thought we should add this now anyway so we can start looking at the stats in CI.