### PR TITLE
Second round of adjustments to dashboard narratives

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -46,7 +46,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.0.2
+        version: 1.1.0
         cwd: src/plugin
         source:
             bower: {}
@@ -134,7 +134,7 @@ modules:
             bower: {}
     -
         globalName: kbase-service-clients-js
-        version: 1.1.1
+        version: 1.2.0
         source:
             bower: {}
     -

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -50,7 +50,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.0.2
+        version: 1.1.0
         cwd: src/plugin
         source:
             bower: {}
@@ -88,7 +88,7 @@ modules:
             bower: {}
     -
         globalName: kbase-service-clients-js
-        version: 1.1.1
+        version: 1.2.0
         source:
             bower: {}
     -

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>KBase | User Interface ALPHA</title>
+        <title>KBase | Interface</title>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script src="/mustard.js"></script>

--- a/src/client/modules/plugins/mainwindow/modules/titleWidget.js
+++ b/src/client/modules/plugins/mainwindow/modules/titleWidget.js
@@ -23,6 +23,7 @@ define([
                         // as easily do this ourselves.
                         this.recv('ui', 'setTitle', function (data) {
                             this.set('title', data);
+                            window.document.title = data + ' | KBase';
                         }.bind(this));
                     },
                     render: function () {

--- a/src/client/modules/plugins/mainwindow/modules/titleWidget.js
+++ b/src/client/modules/plugins/mainwindow/modules/titleWidget.js
@@ -22,8 +22,14 @@ define([
                         // get automatic event listener cleanup. We could almost
                         // as easily do this ourselves.
                         this.recv('ui', 'setTitle', function (data) {
+                            if (typeof data !== 'string') {
+                                return;
+                            }
                             this.set('title', data);
-                            window.document.title = data + ' | KBase';
+                            var anonDiv = document.createElement('div'), text;
+                            anonDiv.innerHTML = data;
+                            text = anonDiv.textContent || '';
+                            window.document.title = text + ' | KBase';
                         }.bind(this));
                     },
                     render: function () {

--- a/src/client/modules/plugins/userprofile/modules/widgets/userProfileEditor.js
+++ b/src/client/modules/plugins/userprofile/modules/widgets/userProfileEditor.js
@@ -880,7 +880,7 @@ define([
                         this.places.title.html('You - ' + this.userProfile.getProp('user.realname') + ' (' + this.userProfile.getProp('user.username') + ')');
 
                         this.runtime.send('ui', 'clearButtons');
-                        this.runtime.send('ui', 'setTitle', 'Viewing your profile');
+                        this.runtime.send('ui', 'setTitle', 'Your Profile');
 
                         this.runtime.send('ui', 'addButton', {
                             name: 'account',
@@ -944,7 +944,7 @@ define([
                     } else {
                         var title = this.userProfile.getProp('user.realname') + ' (' + this.userProfile.getProp('user.username') + ')';
                         this.places.title.html(title);
-                        this.runtime.send('ui', 'setTitle', 'Viewing profile for ' + title);
+                        this.runtime.send('ui', 'setTitle', 'Viewing Profile for ' + title);
                     }
                     this.renderPicture();
                     this.places.content.html(this.renderTemplate('view'));


### PR DESCRIPTION
Updated:
Adjust to the updated narrative metadata format for methods and apps. Specifically, sdk methods will carry the commit hash. The narrative display on the dashboard now supports the legacy methods, sdk methods, and (for now) the ones stuck in the middle (sdk methods without a hash). Error and warning state for methods are reflected with minimal tooltip help to explain

Window title is now set as the ui title area is set.
