### PR TITLE
Fix inability to close alerts on login page

### DIFF
--- a/src/client/modules/plugins/login/modules/login.js
+++ b/src/client/modules/plugins/login/modules/login.js
@@ -138,7 +138,18 @@ function (html, $, Promise, Plugin) {
 
             return div({class: 'container', style: 'margin-top: 4em', id: panelId}, [
                 div({}, [
-                    div({style: 'position:absolute; background-image: url(' + doodlePath + '); background-repeat:no-repeat; background-size:35%; top:0; left:0; bottom: 0; right: 0; opacity: 0.1'})
+                    div({style: {
+                            position: 'absolute',
+                            backgroundImage: 'url(' + doodlePath + ')',
+                            backgroundRepeat: 'no-repeat',
+                            backgroundSize: '35%',
+                            top: '0',
+                            left: '0',
+                            bottom: '0',
+                            right: '0',
+                            opacity: '0.1',
+                            zIndex: '-1000'
+                        }})
                 ]),
                 div({class: 'row'}, [
                     div({class: 'col-sm-7 col-sm-offset-1'}, [

--- a/src/client/modules/plugins/mainwindow/modules/loginWidget.js
+++ b/src/client/modules/plugins/mainwindow/modules/loginWidget.js
@@ -17,7 +17,7 @@ define([
                     name: 'RuntimeMissing',
                     message: 'The runtime argument is required but is missing',
                     suggestion: 'This is an application error, and no fault of yours.'
-                }
+                };
             }
 
             var button = html.tag('button'),


### PR DESCRIPTION
The "doodle" background image was covering the alerts, making then unclosable. Send the doodle back in the z-index.