### PR TITLE
Updated build process to properly handle search deploy config.

### DIFF
--- a/mutations/build.js
+++ b/mutations/build.js
@@ -613,17 +613,19 @@ function setupBuild(state) {
         });
 }
 
+/**
+ * Returns a Promise that sets the search config 'setup' to use the right target based on this build config.
+ * Any errors are expected to be caught by the caller's catch().
+ */
 function configureSearch(state) {
-    return fs.readJson(state.environment.path.concat(['build', 'client', 'search', 'config.json']).join('/'),
+    var configFile = state.environment.path.concat(['build', 'client', 'search', 'config.json']).join('/');
+    return fs.readJson(configFile,
         function(err, config) {
             var target = state.config.targets.deploy;
-            console.log(state);
-            console.log('SEARCH CONFIG: ' + config.setup);
             config.setup = target;
-            return fs.outputJson(state.environment.path.concat(['build', 'client', 'search', 'config.json']).join('/'), config);
+            return fs.outputJson(configFile, config);
         }
     );
-
 }
 
 function fetchPackagesWithBower(state) {

--- a/mutations/build.js
+++ b/mutations/build.js
@@ -588,6 +588,9 @@ function setupBuild(state) {
             return fs.moveAsync(from.join('/'), to.join('/'));
         })
         .then(function () {
+            return configureSearch(state);
+        })
+        .then(function () {
             return fs.moveAsync(root.concat(['bower.json']).join('/'), root.concat(['build', 'bower.json']).join('/'));
         })
         .then(function () {
@@ -608,6 +611,19 @@ function setupBuild(state) {
         .then(function () {
             return state;
         });
+}
+
+function configureSearch(state) {
+    return fs.readJson(state.environment.path.concat(['build', 'client', 'search', 'config.json']).join('/'),
+        function(err, config) {
+            var target = state.config.targets.deploy;
+            console.log(state);
+            console.log('SEARCH CONFIG: ' + config.setup);
+            config.setup = target;
+            return fs.outputJson(state.environment.path.concat(['build', 'client', 'search', 'config.json']).join('/'), config);
+        }
+    );
+
 }
 
 function fetchPackagesWithBower(state) {

--- a/mutations/configure.js
+++ b/mutations/configure.js
@@ -73,34 +73,34 @@ function main(type) {
             path: mutant.rtrunc(process.cwd().split('/'), 1)
         }
     })
-        .then(function (state) {
-            return loadBuildConfig(state);
-        })
-        .then(function (state) {
-            return [state, loadDeployConfig(state)];
-        })
-        .spread(function (state) {
-            var deployConfig = state.config.kbDeployConfig['kbase-ui'].deploy_target,
-                deployPath = deployConfig.split('/');
+    .then(function (state) {
+        return loadBuildConfig(state);
+    })
+    .then(function (state) {
+        return [state, loadDeployConfig(state)];
+    })
+    .spread(function (state) {
+        var deployConfig = state.config.kbDeployConfig['kbase-ui'].deploy_target,
+            deployPath = deployConfig.split('/');
 
-            state.deployPath = deployPath;
+        state.deployPath = deployPath;
 
-            // Ensure the directory is there, yet has no files.
-            return [state, mutant.ensureEmptyDir(deployPath)];
-        })
-        .spread(function (state) {
-            var sourceDir = state.environment.path.concat(['build', 'dist', 'client']),
-                destDir = state.deployPath;
+        // Ensure the directory is there, yet has no files.
+        return [state, mutant.ensureEmptyDir(deployPath)];
+    })
+    .spread(function (state) {
+        var sourceDir = state.environment.path.concat(['build', 'dist', 'client']),
+            destDir = state.deployPath;
 
-            return [state, mutant.copyFiles(sourceDir, destDir, '**/*')];
-        })
-        .spread(function (state) {
-            console.log('Successfully deployed to ' + state.deployPath.join('/'));
-        })
-        .catch(function (err) {
-            console.log('ERROR');
-            console.log(err);
-        });
+        return [state, mutant.copyFiles(sourceDir, destDir, '**/*')];
+    })
+    .spread(function (state) {
+        console.log('Successfully deployed to ' + state.deployPath.join('/'));
+    })
+    .catch(function (err) {
+        console.log('ERROR');
+        console.log(err);
+    });
 }
 
 

--- a/src/search/config.json
+++ b/src/search/config.json
@@ -40,6 +40,45 @@
          }
       }
    },
+   "next": {
+      "workspace_url": "https://next.kbase.us/services/ws/",
+      "fba_url": "https://next.kbase.us/services/KBaseFBAModeling/",
+      "user_job_state_url": "https://next.kbase.us/services/userandjobstate",
+      "search_url": "https://next.kbase.us/services/search/",
+      "homology_service_url": "https://next.kbase.us/services/homology_service/",
+      "user_profile_url": "https://next.kbase.us/services/user_profile/rpc",
+      "login_url": "https://kbase.us/services/authorization/Sessions/Login",
+      "narrative_method_store_url": "https://next.kbase.us/services/narrative_method_store/rpc",
+      "awe": "https://next.kbase.us/services/awe-api", 
+      "data_import_export": "https://next.kbase.us/services/data_import_export", 
+      "gene_families": "https://next.kbase.us/services/gene_families", 
+      "genomeCmp": "https://next.kbase.us/services/genome_comparison/jsonrpc", 
+      "shock": "https://next.kbase.us/services/shock-api", 
+      "transform": "https://next.kbase.us/services/transform", 
+      "trees": "https://next.kbase.us/services/trees", 
+      "user_profile": "https://next.kbase.us/services/user_profile/rpc", 
+      "feature_values": "https://next.kbase.us/services/feature_values/jsonrpc",
+      "dashboard_metrics_url": "/userMetrics",
+      "session": {
+         "cookie": {
+            "max-age": 5184000
+         }
+      },
+      "kbase_clients": {
+         "defaults": {
+            "timeout": 900000
+         }
+      },
+      "docsite": {
+         "baseUrl": "http://kbase.us",
+         "host": "kbase.us",
+         "paths": {
+            "about": "/what-is-kbase",
+            "contact": "/contact-us",
+            "browserSupport": "/supported-browsers"
+         }
+      }
+   },
    "ci": {
       "workspace_url": "https://ci.kbase.us/services/ws/",
       "fba_url": "https://ci.kbase.us/services/KBaseFBAModeling/",


### PR DESCRIPTION
We talked some time ago about setting search's config.json to point to the right place on deploy. Guess this either fell through some cracks, or got lost with updates to the deploy tools.

Anyway, this adds the right environment to the config on kbase-ui build.

Eventually we should talk about having a global spot for all front-end configurations, but this'll get us through for now.