### PR TITLE
Fix dataTable call on non-existent table on user profile page

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -46,7 +46,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.1.5
+        version: 1.1.6
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -50,7 +50,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.1.5
+        version: 1.1.6
         cwd: src/plugin
         source:
             bower: {}

--- a/src/client/modules/plugins/userprofile/modules/widgets/userProfileBase.js
+++ b/src/client/modules/plugins/userprofile/modules/widgets/userProfileBase.js
@@ -238,7 +238,8 @@ define([
 
                     this.setInitialState()
                         .then(function () {
-                            return this.refresh();
+                            this.refresh();
+                            return null;
                         }.bind(this))
                         .catch(function (err) {
                             this.setError(err);
@@ -304,7 +305,7 @@ define([
             setParam: {
                 value: function (path, value) {
                     Utils.setProp(this.params, path, value);
-                    this.refresh().done();
+                    this.refresh();
                 }
             },
             getParam: {
@@ -316,7 +317,8 @@ define([
                 value: function () {
                     this.setInitialState()
                         .then(function () {
-                            return this.refresh();
+                            this.refresh();
+                            return null;
                         }.bind(this))
                         .catch(function (err) {
                             this.setError(err);
@@ -325,17 +327,12 @@ define([
             },
             refresh: {
                 value: function () {
-                    return new Promise(function (resolve) {
-                        if (!this.refreshTimer) {
-                            this.refreshTimer = window.setTimeout(function () {
-                                this.refreshTimer = null;
-                                this.render();
-                                resolve();
-                            }.bind(this), 0);
-                        } else {
-                            resolve();
-                        }
-                    }.bind(this));
+                    if (!this.refreshTimer) {
+                        this.refreshTimer = window.setTimeout(function () {
+                            this.refreshTimer = null;
+                            this.render();
+                        }.bind(this), 0);
+                    }
                 }
             },
             // STATE CHANGES
@@ -350,13 +347,7 @@ define([
                 value: function (path, value, norefresh) {
                     Utils.setProp(this.state, path, value);
                     if (!norefresh) {
-                        this.refresh()
-                            .then(function () {
-                                return null;
-                            })
-                            .catch(function (err) {
-                                // do something.
-                            });
+                        this.refresh();
                     }
                 }
             },
@@ -380,7 +371,7 @@ define([
                         message: errorText,
                         original: errorValue
                     }
-                    this.refresh().done();
+                    this.refresh();
                 }
             },
             checkState: {
@@ -411,6 +402,7 @@ define([
                     })
                         .then(function () {
                             this.refresh();
+                            return null;
                         }.bind(this));
                 }
             },
@@ -422,6 +414,7 @@ define([
                         force: true
                     }).then(function () {
                         this.refresh();
+                        return null;
                     }.bind(this));
                 }
             },
@@ -692,12 +685,12 @@ define([
             },
             addSuccessMessage: {
                 value: function (message) {
-                    
+
                     this.runtime.send('ui', 'alert', {
                         type: 'success',
                         message: message
                     });
-                    
+
 //                    
 //                    if (message === undefined) {
 //                        message = title;
@@ -713,7 +706,7 @@ define([
             },
             addWarningMessage: {
                 value: function (message) {
-                     this.runtime.send('ui', 'alert', {
+                    this.runtime.send('ui', 'alert', {
                         type: 'warning',
                         message: message
                     });
@@ -731,7 +724,7 @@ define([
             },
             addErrorMessage: {
                 value: function (message) {
-                     this.runtime.send('ui', 'alert', {
+                    this.runtime.send('ui', 'alert', {
                         type: 'error',
                         message: message
                     });

--- a/src/client/modules/plugins/userprofile/resources/BrowseNarratives/templates/authorized.html
+++ b/src/client/modules/plugins/userprofile/resources/BrowseNarratives/templates/authorized.html
@@ -9,34 +9,34 @@
     </div>
 </div>
 
-<table cellpadding="0" cellspacing="0" border="0" class="table table-bordered table-striped" id="narrative_table_{{env.generatedId}}">
     {% if state.narratives | length > 0 %}
-    <thead>
-        <tr>
-            <th>Narrative</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for narrative in state.narratives %}
-        <tr>
+    <table cellpadding="0" cellspacing="0" border="0" class="table table-bordered table-striped" id="narrative_table_{{env.generatedId}}">
+        <thead>
+            <tr>
+                <th>Narrative</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for narrative in state.narratives %}
+            <tr>
 
-            <td><a target="_blank" href="{{ env.getConfig('services.narrative.url') }}/narrative/{{narrative.obj_id}}">{{narrative.title}}</a><br><i>modified on {{narrative.moddate | dateFormat }}
-                    {% if narrative.description %}<p>{{narrative.description}}</p>{% endif %}</td>
-        </tr>
+                <td><a target="_blank" href="{{ env.getConfig('services.narrative.url') }}/narrative/{{narrative.obj_id}}">{{narrative.title}}</a><br><i>modified on {{narrative.moddate | dateFormat }}
+                        {% if narrative.description %}<p>{{narrative.description}}</p>{% endif %}</td>
+            </tr>
 
-        {% endfor %}
-    </tbody>
+            {% endfor %}
+        </tbody>
+    </table>
     {% else %}
 
         {% if env.isOwner %}You do not own any{% else %}This user does not own any{% endif %} narratives.
 
     {% endif %}
     
-</table>
 <script>
     require(['jquery', 'datatables', 'datatables_bootstrap'], function ($) {
-        var table = $('#narrative_table_{{env.generatedId}}');
-        if (table) {
+        var table = $('#narrative_table_{{env.generatedId}}');      
+        if (table.get(0)) {
             table.dataTable({
         initComplete: function (settings) {
             var api = this.api();

--- a/src/client/modules/plugins/userprofile/resources/CommonCollaboratorNetwork/templates/authorized.html
+++ b/src/client/modules/plugins/userprofile/resources/CommonCollaboratorNetwork/templates/authorized.html
@@ -12,6 +12,7 @@
 	</div>
 </div>
 
+{% if state.collaborators | length > 0 %}
 <table class="table table-bordered table-striped" id="collaborator_table_{{generatedId}}">
 	<thead>
 	<tr>
@@ -30,22 +31,33 @@
 {% endfor %}
 	</tbody>
 </table>
+{% else %}
+  You do not have any collaborators in common with this user.
+{% endif %}
 
 <script>
 require(['jquery', 'datatables','datatables_bootstrap'], function ($) {
-    $('#collaborator_table_{{env.generatedId}}').dataTable({
-        initComplete: function (settings) {
-            var api = this.api();
-            var rowCount = api.data().length;
-            var pageSize = api.page.len();
-            var wrapper = api.settings()[0].nTableWrapper;
-            if (rowCount <= pageSize) {
-                $(wrapper).find('.dataTables_length').hide();
-                $(wrapper).find('.dataTables_filter').hide();
-                $(wrapper).find('.dataTables_paginate').hide();
-                $(wrapper).find('.dataTables_info').hide();
-            }
+    try {
+        var table = $('#collaborator_table_{{env.generatedId}}');
+        if (table.get(0)) {
+            table.dataTable({
+                initComplete: function (settings) {
+                    var api = this.api();
+                    var rowCount = api.data().length;
+                    var pageSize = api.page.len();
+                    var wrapper = api.settings()[0].nTableWrapper;
+                    if (rowCount <= pageSize) {
+                        $(wrapper).find('.dataTables_length').hide();
+                        $(wrapper).find('.dataTables_filter').hide();
+                        $(wrapper).find('.dataTables_paginate').hide();
+                        $(wrapper).find('.dataTables_info').hide();
+                    }
+                }
+            });
         }
-    });
+    } catch (err) {
+        console.error('ERROR rendering collaborators table');
+        console.error(err);
+    }
 });
 </script>

--- a/src/client/modules/startup.js
+++ b/src/client/modules/startup.js
@@ -13,6 +13,10 @@
                     return;
                 }
                 break;
+            case 'require':
+                console.error('Error in require-loaded code');
+                console.error(err);
+                return;
             case 'scripterror':
                 if (err.requireModules) {
                     if (err.requireModules.some(function (moduleName) {
@@ -35,6 +39,14 @@
                     }
                 }
                 break;            
+            case 'define':
+            case 'fromtexteval':
+            case 'mismatch':
+            case 'requireargs':
+            case 'nodefine':
+            case 'importscripts':
+            case 'timeout':
+                break;
         }
 
 //        console.error('AMD Error');


### PR DESCRIPTION
This was a persistent if harmless bug, but rose its ugly head with the new global error handling code, which defaults to a big error dialog taking over the page. Well, this fixes the underlying bug, but also reverts the global error handler to the old behavior of logging to the console. That carries the risk of burying bugs, but testing should inspect the console for errors anyway.