### PR TITLE
Fixed script load order in loading.html

### DIFF
--- a/src/client/loading.html
+++ b/src/client/loading.html
@@ -3,8 +3,8 @@
     <head>
         <title>KBase Narrative Interface</title>
         <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+        <script src="/require-config.js"></script>
         <script src="/modules/bower_components/requirejs/require.js"></script>
-        <script src="/modules/require-config.js"></script>
     </head>
     <body>
         <div style="text-align:center;">


### PR DESCRIPTION
New require-config location and module load order needs to be done in the narrative in-between loading page.