### PR TITLE
Update urls in config related to kbase.us and globus, update dashboard

### DIFF
--- a/config/deploy/deploy-appdev.cfg
+++ b/config/deploy/deploy-appdev.cfg
@@ -37,14 +37,14 @@ status_page_url = http://kbase.us/internal/status
 submit_jira_ticket_url = https://atlassian.kbase.us/secure/CreateIssueDetails!init.jspa?pid=10200&issuetype=1&description=#Narrative%
 
 # Documentation
-doc_login_help = http://kbase.us/new-to-kbase/
+doc_login_help = http://kbase.us/help
 doc_narrative_guide = http://kbase.us/narrative-guide
 doc_tutorials = http://kbase.us/tutorials
 doc_apps = http://kbase.us/apps
-signup_url = http://kbase.us/sign-up-for-a-kbase-account
+signup_url = http://kbase.us/sign-up
 
 # Globus
-reset_password_url = https://www.globusid.org/forgot
+reset_password_url = http://kbase.us/reset-password
 update_profile_url = https://www.globusid.org/profile
 user_account_url = https://gologin.kbase.us/globus-app/account
 

--- a/config/deploy/deploy-ci.cfg
+++ b/config/deploy/deploy-ci.cfg
@@ -37,14 +37,14 @@ status_page_url = http://kbase.us/internal/status
 submit_jira_ticket_url = https://atlassian.kbase.us/secure/CreateIssueDetails!init.jspa?pid=10200&issuetype=1&description=#Narrative%
 
 # Documentation
-doc_login_help = http://kbase.us/new-to-kbase/
+doc_login_help = http://kbase.us/help
 doc_narrative_guide = http://kbase.us/narrative-guide
 doc_tutorials = http://kbase.us/tutorials
 doc_apps = http://kbase.us/apps
-signup_url = http://kbase.us/sign-up-for-a-kbase-account
+signup_url = http://kbase.us/sign-up
 
 # Globus
-reset_password_url = https://www.globusid.org/forgot
+reset_password_url = http://kbase.us/reset-password
 update_profile_url = https://www.globusid.org/profile
 user_account_url = https://gologin.kbase.us/globus-app/account
 

--- a/config/deploy/deploy-next.cfg
+++ b/config/deploy/deploy-next.cfg
@@ -37,14 +37,14 @@ status_page_url = http://kbase.us/internal/status
 submit_jira_ticket_url = https://atlassian.kbase.us/secure/CreateIssueDetails!init.jspa?pid=10200&issuetype=1&description=#Narrative%
 
 # Documentation
-doc_login_help = http://kbase.us/new-to-kbase/
+doc_login_help = http://kbase.us/help
 doc_narrative_guide = http://kbase.us/narrative-guide
 doc_tutorials = http://kbase.us/tutorials
 doc_apps = http://kbase.us/apps
-signup_url = http://kbase.us/sign-up-for-a-kbase-account
+signup_url = http://kbase.us/sign-up
 
 # Globus
-reset_password_url = https://www.globusid.org/forgot
+reset_password_url = http://kbase.us/reset-password
 update_profile_url = https://www.globusid.org/profile
 user_account_url = https://gologin.kbase.us/globus-app/account
 

--- a/config/deploy/deploy-prod.cfg
+++ b/config/deploy/deploy-prod.cfg
@@ -37,14 +37,14 @@ status_page_url = http://kbase.us/internal/status
 submit_jira_ticket_url = https://atlassian.kbase.us/secure/CreateIssueDetails!init.jspa?pid=10200&issuetype=1&description=#Narrative%
 
 # Documentation
-doc_login_help = http://kbase.us/new-to-kbase/
+doc_login_help = http://kbase.us/help
 doc_narrative_guide = http://kbase.us/narrative-guide
 doc_tutorials = http://kbase.us/tutorials
 doc_apps = http://kbase.us/apps
-signup_url = http://kbase.us/sign-up-for-a-kbase-account
+signup_url = http://kbase.us/sign-up
 
 # Globus
-reset_password_url = https://www.globusid.org/forgot
+reset_password_url = http://kbase.us/reset-password
 update_profile_url = https://www.globusid.org/profile
 user_account_url = https://gologin.kbase.us/globus-app/account
 

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -46,7 +46,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.1.6
+        version: 1.2.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -50,7 +50,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.1.6
+        version: 1.2.0
         cwd: src/plugin
         source:
             bower: {}


### PR DESCRIPTION
- improved urls for kbase.us documentation links:
  new-to-kbase becomes help (which is aliased to new-to-kbase at kbase.us)
  sign up now points to the kbase.us hosted signup page
  password reset now points to the new kbase.us hosted password reset page
- dashboard updated to extend the narrative search to narrative owners (wip)