### PR TITLE
new google analytics api sidetracks browser blockers; jgi/import route restored; other fixes

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -39,7 +39,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.2.6
+        version: 1.3.1
         cwd: src/plugin
         source:
             bower: {}
@@ -124,12 +124,12 @@ plugins:
 modules:
     -
         globalName: kbase-ui-widget
-        version: 1.0.5
+        version: 1.0.7
         source:
             bower: {}
     -
         globalName: kbase-common-js
-        version: 1.2.0
+        version: 1.3.1
         source:
             bower: {}
     -

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -36,7 +36,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.2.6
+        version: 1.3.1
         cwd: src/plugin
         source:
             bower: {}
@@ -78,12 +78,12 @@ plugins:
 modules:
     -
         globalName: kbase-ui-widget
-        version: 1.0.5
+        version: 1.0.7
         source:
             bower: {}
     -
         globalName: kbase-common-js
-        version: 1.2.0
+        version: 1.3.1
         source:
             bower: {}
     -

--- a/src/client/modules/app/App.js
+++ b/src/client/modules/app/App.js
@@ -107,6 +107,8 @@ define([
             if (!rootNode) {
                 throw new Error('Cannot set root widget without a root node');
             }
+            // remove anything on the root mount, such as a waiter.
+            rootNode.innerHTML = '';
             if (!rootMount) {
                 // create the root mount.
                 rootMount = widgetMountFactory.make({
@@ -270,7 +272,9 @@ define([
                 })
                 .then(function () {
                     // kick off handling of the current route.
-                    api.service('analytics').page();
+                    api.service('analytics').pageView('/index');
+                    // remove the loading status.
+                    
                     send('app', 'do-route');
                     return api;
                 });

--- a/src/client/modules/app/analytics.js
+++ b/src/client/modules/app/analytics.js
@@ -1,46 +1,87 @@
 /*global define*/
 /*jslint white:true,browser:true */
 define([
-    'bluebird'
-], function (Promise) {
+    'bluebird',
+    'uuid',
+    'kb/common/ajax'
+        // 'https://www.google-analytics.com/analytics.js'
+], function (Promise, Uuid, Ajax) {
     'use strict';
-    
+
     function factory(config) {
-        var gaLoaded = false;
+        var code = config.code,
+            host = config.host,
+            uuid = new Uuid(4).format();
 
         function init(config) {
             // This is what the analytics plugin will look for when it loads.
-            window.GoogleAnalyticsObject = 'ga';
+            //window.GoogleAnalyticsObject = 'ga';
             // The ga object is simply a queue, until the analytics script loads.
-            window.ga = function () {
-                if (!window.ga.q) {
-                    window.ga.q = [];
-                }
-                window.ga.q.push(arguments);
-            }
+//            window.ga = function () {
+//                if (!window.ga.q) {
+//                    window.ga.q = [];
+//                }
+//                window.ga.q.push(arguments);
+
+//            };
 
             // Queue up the initialization 'create'
-            window.ga('create', config.code, config.host || 'auto');
+//            console.log(GA);
+//            if (window.ga) {
+//                window.ga('create', config.code, config.host || 'auto');
+//            }
 
             // Asynchrously load the ga app -- it picks up the queue left in window.ga
-            return new Promise(function (resolve, reject) {
-                return require([
-                    '//www.google-analytics.com/analytics.js'
-                ], function () {                
-                    resolve();
-                }, function (err) {
-                    console.error('Error loading GA');
-                    console.error(err);
-                    reject(err);
-                });
-
-            })
+//            return new Promise(function (resolve, reject) {
+//                return require([
+//                    '//www.google-analytics.com/analytics.js'
+//                ], function () {                
+//                    resolve();
+//                }, function (err) {
+//                    console.error('Error loading GA');
+//                    console.error(err);
+//                    reject(err);
+//                });
+//
+//            });
         }
 
-        function send(what) {
-            if (window.ga) {
-                window.ga('send', what || 'pageview');
-            }
+        function create() {
+
+        }
+
+        function encodeQuery(params) {
+            return Object.keys(params).map(function (key) {
+                return [encodeURIComponent(key), encodeURIComponent(params[key])].join('=');
+            }).join('&');
+        }
+
+        function send(path) {
+            var data = encodeQuery({
+                v: 1,
+                tid: code,
+                cid: uuid,
+                t: 'pageview',
+                dp: path
+            });
+            // console.log('SENDING', data);
+            Ajax.post({
+                url: 'https://www.google-analytics.com/collect',
+                header: {
+                    'Content-type': 'application/x-www-form-urlencoded'
+                },
+                withCredentials: true,
+                data: data
+            })
+                .then(function (result) {
+                    //alert('yay, sent pageview to analytics');
+                    // console.log(result);
+                })
+                .catch(function (err) {
+                    //alert('boo, it failed. check the log');
+                
+                    console.error('ERROR sending to GA', err);
+                });
         }
 
         return {
@@ -48,7 +89,7 @@ define([
             send: send
         };
     }
-    
+
     return {
         make: function (config) {
             return factory(config);

--- a/src/client/modules/app/services/analytics.js
+++ b/src/client/modules/app/services/analytics.js
@@ -6,31 +6,37 @@ define([
 ], function (Promise, GoogleAnalytics) {
     'use strict';
     function factory(config) {
-        var runtime = config.runtime, analytics = GoogleAnalytics.make(config);
+        var runtime = config.runtime, 
+            analytics = GoogleAnalytics.make({
+                code: runtime.config('resources.googleAnalytics.code'),
+                host: runtime.config('deployment.hostname')
+            });
 
-        function page() {
-            analytics.send('pageview');
+        
+
+        function pageView(path) {
+            analytics.send(path);
         }
 
         // API
 
         function start() {
-            return analytics.init({
-                code: runtime.config('resources.googleAnalytics.code'),
-                host: runtime.config('deployment.hostname')
-            });
+//            return analytics.init({
+//                code: runtime.config('resources.googleAnalytics.code'),
+//                host: runtime.config('deployment.hostname')
+//            });
         }
         function stop() {
             // nothing to do?
-            return Promise.try(function () {
-                return true;
-            });
+//            return Promise.try(function () {
+//                return true;
+//            });
         }
 
         return {
             start: start,
             stop: stop,
-            page: page
+            pageView: pageView
         };
     }
 

--- a/src/client/modules/plugins/mainwindow/modules/widgets/error.js
+++ b/src/client/modules/plugins/mainwindow/modules/widgets/error.js
@@ -96,7 +96,7 @@ define([
             } else {
                 error = {
                     type: 'Unknown',
-                    message: error.message
+                    message: error && error.message
                 };
             }
 

--- a/src/client/modules/startup.js
+++ b/src/client/modules/startup.js
@@ -1,8 +1,30 @@
 /*global require, KBaseFallback*/
 /*jslint white:true*/
 (function (root) {
+    // First display a loading message in case we have some latency issues...
+
+    function showInitialLoadingView() {
+        var status = root.document.getElementById('root');
+        status.innerHTML =
+            '<div style="padding: 0; border-bottom: 5px solid #E0E0E0;">' +
+            '	<div style="position: relative; height: 65px" >' +
+            '		<div style="display: inline-block;width: 52px;">&nbsp;' +
+            '		</div>' +
+            '		<div style="padding: 4px; display: inline-block; height: 100%; vertical-align: top" id="kb_html_4">' +
+            '                   <a href="http://kbase.us"><img id="logo" src="/modules/plugins/mainwindow/resources/images/kbase_logo.png" width="46"></a>' +
+            '		</div>' +
+            '		<div style="padding: 4px; display: inline-block; height: 100%; vertical-align: top" id="kb_html_5">' +
+            '                   <div style="font-weight: bold; font-size: 150%; margin: 18px 0 0 15px; ">' +
+            '                       ' +
+            '		   </div>' +
+            '		</div>' +
+            '	</div>' +
+            '</div>';
+    }
+    
     function handleGlobalError(err) {
         'use strict';
+
 
         switch (err.requireType) {
             case 'notloaded':
@@ -13,6 +35,28 @@
                     return;
                 }
                 break;
+            case 'timeout':
+                if (err.requireModules) {
+                    if (err.requireModules.some(function (module) {
+                        if (module === '//www.google-analytics.com/analytics.js') {
+                            return true;
+                        }
+                        return false;
+                    })) {
+                        KBaseFallback.showError({
+                            title: 'Analytics Blocked (timeout)',
+                            content: [
+                                'A browser setting, plugin, or other constraint has prevented the Analytics module from loading. KBase uses this module to measure usage of the Narrative Interface. The Narrative Interface will not operate with this constraint in place.'
+                            ],
+                            references: [
+                                {
+                                    title: 'Incompatible Plugins',
+                                    url: 'http://kbase.us/incompatible-plugins'
+                                }
+                            ]
+                        })
+                    }
+                }
             case 'require':
                 console.error('Error in require-loaded code');
                 console.error(err);
@@ -24,9 +68,9 @@
                     })) {
                         // KBaseFallback.redirect('/pages/gablocked.html');
                         KBaseFallback.showError({
-                            title: 'Analytics Blocked',
+                            title: 'Analytics Blocked (scripterror)',
                             content: [
-                                'A browser setting, plugin, or other constraint has prevented the Analytics module from loading. KBase uses this module to measure usage of the Narrative Interface (NI). The Narrative Interface will not operate with this constraint in place.'
+                                'A browser setting, plugin, or other constraint has prevented the Analytics module from loading. KBase uses this module to measure usage of the Narrative Interface. The Narrative Interface will not operate with this constraint in place.'
                             ],
                             references: [
                                 {
@@ -38,14 +82,13 @@
                         return;
                     }
                 }
-                break;            
+                break;
             case 'define':
             case 'fromtexteval':
             case 'mismatch':
             case 'requireargs':
             case 'nodefine':
             case 'importscripts':
-            case 'timeout':
                 break;
         }
 
@@ -73,7 +116,7 @@
 
         throw err;
     }
-    
+
     function handleStartupError(err) {
         'use strict';
 
@@ -128,7 +171,7 @@
 
         throw err;
     }
-    
+
     require.onError = handleGlobalError;
 
     require(['app/main'], function (main) {
@@ -138,8 +181,21 @@
         }
         main.start()
             .catch(function (err) {
-                document.getElementById('root').innerHTML = 'Error starting KBase UI. Please consult the browser error log.';
-                console.error('Startup Error', err);
+                KBaseFallback.showError({
+                    title: 'KBase Application Startup Error',
+                    content: [
+                        'An error has occurred while starting the the KBase Application.',
+                        err.message
+                    ],
+                    references: [
+                        {
+                            title: 'Reporting Application Errors',
+                            url: 'http://kbase.us/contact-us'
+                        }
+                    ]
+                });
+                // document.getElementById('root').innerHTML = 'Error starting KBase UI. Please consult the browser error log.';
+                // console.error('Startup Error', err);
             });
     }, function (err) {
         handleStartupError(err);

--- a/tools/server/server2.js
+++ b/tools/server/server2.js
@@ -1,0 +1,295 @@
+/*global process, console, require*/
+var Promise = require('bluebird');
+var static = require('node-static');
+var path = require('path');
+var fs = Promise.promisifyAll(require('fs'));
+var execAsync = Promise.promisify(require('child_process').exec);
+var open = require('open');
+var yaml = require('js-yaml');
+var pathExists = require('path-exists');
+var http = require('http');
+var path = require('path');
+var url = require('url');
+
+function loadYaml(path) {
+    'use strict';
+    var yamlPath = path.join('/');
+    return fs.readFileAsync(yamlPath, 'utf8')
+        .then(function (contents) {
+            return yaml.safeLoad(contents);
+        });
+}
+
+function loadBuildConfig(state) {
+    'use strict';
+    return Promise.resolve(pathExists('../../dev/config'))
+        .then(function (devExists) {
+            var configRoot;
+            if (devExists) {
+                configRoot = ['..', '..', 'dev', 'config'];
+                return [configRoot, loadYaml(configRoot.concat(['builds', state.args.build + '.yml']))];
+            } 
+            configRoot = ['..', '..', 'config'];
+            return [configRoot, loadYaml(configRoot.concat(['builds', state.args.build + '.yml']))];
+        })
+        .spread(function (configRoot, config) {
+            state.config.build = config;
+            state.config.root = configRoot;
+            return state;
+        });
+}
+
+function extensionToContentType(extension) {
+    if (!extension || extension.length === 0) {
+        return 'text/html';
+    }
+    var map = {
+        html: 'text/html',
+        js: 'text/javascript',
+        json: 'application/json',
+        yml: 'text/yaml',
+        css: 'text/css',
+        png: 'image/png',
+        jpg: 'image/jpg',
+        gif: 'image/gif',
+        wav: 'audio/wav',
+        woff: 'text/woff'
+    };
+    return map[extension];
+}
+
+function start(state) {
+    var directory = state.args.directory,
+        rootDir,
+        port = state.config.build.server.port,
+        title = 'kbup-' + String(port);
+
+    console.log('Starting local kbase-ui server');
+    console.log('Type      : ' + state.args.build);
+    console.log('Directory : ' + state.args.directory);
+    console.log('Port      : ' + port);
+
+    http.createServer(function (request, response) {
+        if (directory === 'deployed') {
+            // TODO: get this from the deploy config
+            rootDir = '/kb/deployment/services/kbase-ui/';
+        } else {
+            rootDir = path.normalize([__dirname, '..', '..', 'build', directory, 'client'].join('/'));
+        }
+        process.title = title;
+        if (!fs.existsSync(rootDir)) {
+            console.log('root dir ' + rootDir + ' does not exist or is not accessible to you');
+            return;
+        }
+        var file = new static.Server(rootDir, {cache: false});
+        console.log('root: ' + rootDir);        
+
+        // Configure.
+        //  var mainRoot = ['..', 'runtime', 'build'];
+        var requestUrl = url.parse(request.url);
+        
+        
+
+        // convert to an array
+        var l = requestUrl.pathname.split('/');
+        var normalized = l.filter(function (pathElement) {
+            var el = pathElement.trim();
+            switch (el) {
+                case '':
+                case '.':
+                case '..':
+                    return false;
+            }
+            return true;
+        });
+
+        var pathList = normalized;
+        // simulate the root index.
+        if (pathList.length === 0) {
+            response.writeHead(302, {'Location': '/index.html'});
+            response.end();
+            return;
+            // pathList = ['htdocs/index.html'];
+        }
+
+
+        var filePath = rootDir.concat(pathList);
+        var extension = path.extname(pathList[pathList.length - 1]);
+        // extend if need to...
+        var contentType = extensionToContentType(extension.substr(1));
+        if (!contentType) {
+            response.writeHead(400);
+            response.end('Extension ' + extension + ' not supported', 'utf-8');
+            return;
+        }
+
+        var filePathString = filePath.join('/');
+        fs.readFile(filePathString)
+            .then(content) {
+                response.writeHead(200, {'Content-Type': contentType});
+                response.end(content, 'utf-8');
+            })
+            .catch(function (error) {
+                console.log('ERROR reading file');
+                console.log(error);
+                if (error.code === 'ENOENT') {
+                    response.writeHead(404);
+                    repsonse.end('Sorry, page not found');
+                } else {
+                    response.writeHead(500);
+                    response.end('Sorry, check with the site admin for error: ' + error.code + ' ..\n');
+                }
+            });
+        });
+
+    }).listen(port);
+    console.log('Server running at ' + port);
+}
+
+function startx(state) {
+    var directory = state.args.directory,
+        rootDir,
+        port = state.config.build.server.port,
+        title = 'kbup-' + String(port);
+
+    console.log('Starting local kbase-ui server');
+    console.log('Type      : ' + state.args.build);
+    console.log('Directory : ' + state.args.directory);
+    console.log('Port      : ' + port);
+
+    if (directory === 'deployed') {
+        // TODO: get this from the deploy config
+        rootDir = '/kb/deployment/services/kbase-ui/';
+    } else {
+        rootDir = path.normalize([__dirname, '..', '..', 'build', directory, 'client'].join('/'));
+    }
+    process.title = title;
+    if (!fs.existsSync(rootDir)) {
+        console.log('root dir ' + rootDir + ' does not exist or is not accessible to you');
+        return;
+    }
+    var file = new static.Server(rootDir, {cache: false});
+    console.log('root: ' + rootDir);
+
+    require('http').createServer(function (request, response) {
+        request.addListener('end', function () {
+            // 
+            // Serve files! 
+            // 
+            file.serve(request, response)
+                .addListener('error', function (err) {
+                    console.log('ERROR: ' + request.url + ':' + err.message);
+                });
+
+        }).resume();
+    }).listen(port);
+    console.log('Preview server started as process: ' + title + ', with id: ' + String(process.pid));
+}
+
+function getServerPid(port) {
+    var title;
+    return execAsync('ps -o pid,command')
+        .then(function (stdout, stderr) {
+            title = 'kbup-' + String(port);
+            return stdout.toString()
+                .split('\n')
+                .map(function (item) {
+                    return item.trim(' ').split(/[ ]+/);
+                })
+                .filter(function (row) {
+                    if (row.length < 2) {
+                        return false;
+                    }
+                    if (row[1] === title) {
+                        return true;
+                    }
+                    return false;
+                });
+        })
+        .then(function (procs) {
+            if (procs.length === 1) {
+                var pid = parseInt(procs[0]);
+                return pid;
+            } else if (procs.length === 0) {
+                throw new Error('No processes matched ' + title);
+            } else {
+                throw new ('Too many processes matched ' + title);
+            }
+        });
+}
+
+function stop(state) {
+    // yeah, well, we'll improve this...
+    console.log('Stopping server on port ' + state.config.build.server.port);
+    getServerPid(state.config.build.server.port)
+        .then(function (pid) {
+            console.log('PID: ' + pid);
+            process.kill(pid);
+        });
+}
+
+function preview(state) {
+    getServerPid(state.config.build.server.port)
+        .then(function () {
+            var port = state.config.build.server.port;
+            var url = 'http://localhost:' + String(port);
+            console.log('Opening browser for ' + url);
+            open(url);
+        })
+        .catch(function (err) {
+            console.log('Cannot preview the site -- server not started');
+        });
+}
+
+function usage() {
+    console.log('node server <cmd>');
+}
+
+function importArgs() {
+
+}
+
+function main(state) {
+    loadBuildConfig(state)
+        .then(function (state) {
+            switch (state.args.action) {
+                case 'start':
+                    start(state);
+                    break;
+                case 'stop':
+                    stop(state);
+                    break;
+                case 'preview':
+                    preview(state);
+                    break;
+                default:
+                    usage(state);
+            }
+        })
+        .catch(function (err) {
+            console.log('ERROR');
+            console.log(err);
+            usage();
+        });
+}
+
+var action = process.argv[2];
+if (action === undefined) {
+    throw new Error('action required: node server <action> <build> <directory>');
+}
+var build = process.argv[3];
+if (build === undefined) {
+    throw new Error('action required: node server <action> <build> <directory>');
+}
+
+var directory = process.argv[4] || 'build';
+
+main({
+    args: {
+        action: action,
+        build: build,
+        directory: directory
+    },
+    config: {
+    }
+});


### PR DESCRIPTION
- in response to browser blockers disrupting the loading of the google analytics library, we now have the beginnings of a g.a. library to utilize direct calls to the GA api; this fits into AMD loading much better
- jg/import, the client tool for push to jgi, is now present again in kbase-ui, and updated
- beginnings of an improved handling slow networks and ad blockers.