### PR TITLE
bump data-api-clients-js version to 1.0.4

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -139,7 +139,7 @@ modules:
             bower: {}
     -
         globalName: kbase-data-api-client-js
-        version: 1.0.3
+        version: 1.0.4
         source:
             bower: {}
     

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -93,6 +93,6 @@ modules:
             bower: {}
     -
         globalName: kbase-data-api-client-js
-        version: 1.0.3
+        version: 1.0.4
         source:
             bower: {}


### PR DESCRIPTION
Updates dist directory to include previous code changes for deployment.