### PR TITLE
Updates to enable UI testing for push-to-jgi data import widget

### DIFF
--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -36,7 +36,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.3.2
+        version: 1.4.0
         cwd: src/plugin
         source:
             bower: {}
@@ -83,7 +83,7 @@ modules:
             bower: {}
     -
         globalName: kbase-common-js
-        version: 1.3.2
+        version: 1.4.0
         source:
             bower: {}
     -

--- a/src/client/modules/plugins/login/modules/login.js
+++ b/src/client/modules/plugins/login/modules/login.js
@@ -136,7 +136,7 @@ function (html, $, Promise, Plugin) {
             eventMan.reset();
             var doodlePath = Plugin.plugin.fullPath + '/doodle.png';
 
-            return div({class: 'container', style: 'margin-top: 4em', id: panelId}, [
+            return div({class: 'container', style: 'margin-top: 4em', dataWidget: 'login', id: panelId}, [
                 div({}, [
                     div({style: {
                             position: 'absolute',
@@ -179,10 +179,10 @@ function (html, $, Promise, Plugin) {
                                 input({type: 'hidden', value: nextURL}),
                                 legend({style: 'text-align: center'}, 'KBase Sign In'),
                                 div({class: 'form-group'}, [
-                                    input({name: 'username', type: 'text', placeholder: 'username', id: 'kbase_username', class: 'form-control form-control-kbase', tabindex: '1'})
+                                    input({name: 'username', type: 'text', placeholder: 'username', id: 'kbase_username', dataElement: 'username', autocomplete: 'off', class: 'form-control form-control-kbase', tabindex: '1'})
                                 ]),
                                 div({class: 'form-group'}, [
-                                    input({name: 'password', type: 'password', placeholder: 'password', id: 'kbase_password', class: 'form-control form-control-kbase', tabindex: '2'})
+                                    input({name: 'password', type: 'password', placeholder: 'password', id: 'kbase_password', dataElement: 'password', autocomplete: 'off', class: 'form-control form-control-kbase', tabindex: '2'})
                                 ]),
                                 div({class: 'form-group'}, [
                                     button({id: 'signinbtn', type: 'submit', class: 'btn btn-primary btn-block btn-kbase', tabindex: '3', 'data-element': 'sign-in'}, [
@@ -222,10 +222,13 @@ function (html, $, Promise, Plugin) {
         function start(params) {
             return Promise.try(function () {
                 runtime.send('ui', 'setTitle', 'Sign in to KBase');
-                runtime.send('ui', 'render', {
-                    node: container,
-                    content: renderForm()
-                });
+                container.innerHTML = renderForm();
+                //runtime.send('ui', 'render', {
+                //    node: container,
+                //    content: renderForm()
+                //});
+                console.log(container.querySelector('[data-element="username"]'));
+                container.querySelector('[data-element="username"]').focus();
                 eventMan.attach($container);
                 if (params.nextrequest) {
                     nextRequest = JSON.parse(params.nextrequest);

--- a/src/client/modules/plugins/mainwindow/modules/widgets/error.js
+++ b/src/client/modules/plugins/mainwindow/modules/widgets/error.js
@@ -72,8 +72,8 @@ define([
             } else if (isType(params.error, serviceError)) {
                 error = {
                     type: params.error.error.name,
-                    message: params.error.error.error,
-                    reason: params.error.error.message
+                    message: params.error.error.message,
+                    reason: params.error.error.error
                 };
             } else if (isType(params.error, uiError)) {
                 // hope it is a compatible obje
@@ -108,7 +108,7 @@ define([
                 error.extended = html.makeObjTable([error.extra], {rotated: true});
             }
 
-            return div({class: 'container-fluid'}, html.makePanel({
+            return div({class: 'container-fluid', dataWidget: 'error'}, html.makePanel({
                 title: params.title,
                 class: 'danger',
                 content: html.makeObjTable([error], {rotated: true})

--- a/src/client/modules/plugins/narrativemanager/modules/createNewPanel.js
+++ b/src/client/modules/plugins/narrativemanager/modules/createNewPanel.js
@@ -66,6 +66,21 @@ define([
                     });
             });
         }
+        
+        function wrapPanel(content) {
+            var div = html.tag('div');
+            return div({class: 'container-fluid'}, [
+                div({class: 'row'}, [
+                    div({class: 'col-md-12'}, [
+                        content
+                    ])
+                ])
+            ]);
+        }
+
+
+        
+        // API
 
         function attach(node) {
             mount = node;
@@ -77,15 +92,15 @@ define([
             var div = html.tag('div'),
                 a = html.tag('a'),
                 p = html.tag('p');
-            container.innerHTML = html.loading('Creating a new Narrative for you...');
+            container.innerHTML = wrapPanel(html.loading('Creating a new Narrative for you...'));
             return new Promise(function (resolve, reject) {
                 createNewNarrative(params)
                     .then(function (result) {
-                        container.innerHTML = div([
-                            p('Should have created and opened a new narrative.'),
-                            p('If it did not happen, use this link:'),
+                        container.innerHTML = wrapPanel([
+                            p('Opening your new Narrative.'),
+                            p('If the Narrative did not open, use this link'),
                             p(a({href: result.redirect.url, target: '_blank'}, [
-                                'Open Your New Narrative: ',
+                                'Open your new Narrative: ',
                                 result.redirect.url
                             ]))
                         ]);

--- a/src/client/modules/plugins/narrativemanager/modules/startPanel.js
+++ b/src/client/modules/plugins/narrativemanager/modules/startPanel.js
@@ -93,6 +93,19 @@ define([
                 });
         }
 
+        function wrapPanel(content) {
+            var div = html.tag('div');
+            return div({class: 'container-fluid'}, [
+                div({class: 'row'}, [
+                    div({class: 'col-md-12'}, [
+                        content
+                    ])
+                ])
+            ]);
+        }
+
+        // API
+
         function attach(node) {
             mount = node;
             container = dom.createElement('div');
@@ -103,19 +116,17 @@ define([
             var div = html.tag('div'),
                 a = html.tag('a'),
                 p = html.tag('p');
-            container.innerHTML = html.loading('Starting or Creating a Narrative for you...');
+            container.innerHTML = wrapPanel(html.loading('Starting or creating a Narrative for you...'));
             return new Promise(function (resolve, reject) {
                 startOrCreateEmptyNarrative(params)
                     .then(function (result) {
-                        container.innerHTML = div({class: 'container-fluid'}, [
-                            div({class: 'col-md-12'}, [
-                                p('Should have opened your narrative.'),
-                                p('If it did not happen, use this link:'),
-                                p(a({href: result.redirect.url, target: '_blank'}, [
-                                    'Open Your New Narrative: ',
-                                    result.redirect.url
-                                ]))
-                            ])
+                        container.innerHTML = wrapPanel([
+                            p('Opening your Narrative.'),
+                            p('If the Narrative did not open, use this link:'),
+                            p(a({href: result.redirect.url, target: '_blank'}, [
+                                'Open your Narrative: ',
+                                result.redirect.url
+                            ]))
                         ]);
                         runtime.send('app', 'redirect', {
                             url: result.redirect.url,
@@ -125,8 +136,8 @@ define([
                     })
                     .catch(function (err) {
                         container.innerHTML = 'ERROR creating and opening a new narrative';
-                        console.log('ERROR creating and opening a new narrative');
-                        console.log(err);
+                        console.error('ERROR creating and opening a new narrative');
+                        console.error(err);
                         reject(err);
                     });
             });


### PR DESCRIPTION
The beginnings of UI testing are already revealing some ways we'll need to tweak the ui. For instance, in order to test rendered elements, we need a uniform system of naming nodes. These changes support some initial ideas for this -- wrapping widgets in data-widget="AAA" and specific elements as data-element="BBB". This needs further work, but it at least gives a handle on being able to create multi-step ui testing scripts.