### PR TITLE
Remove node 0.12 from the travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
   # NB this should be 4.4, we just have to check in occasionally to see if they
   # support it yet.
   - "4.2"


### PR DESCRIPTION
We do not and do not plan to support node 0.12 so no reason to test it.
This was in response to a failed travis run on the most recent PR, in which phantomjs failed under the 0.12 test, but it looks like that may have been a transient issue, because the travis run after accepting the 
PR succeeded.
In any case, we do not need the 0.12 test. We should only test with what we also support.