### PR TITLE
Hotfix for loading the catalog status page

### DIFF
--- a/src/client/modules/plugins/catalog/config.yml
+++ b/src/client/modules/plugins/catalog/config.yml
@@ -155,7 +155,7 @@ install:
             id: catalog_status_widget
             title: App Catalog Status
             config:
-                jqueryName: KBaseCatalogStatusViewer
+                jqueryName: KBaseCatalogStatus
             type: kbwidget
         -
             module: catalog_admin_widget


### PR DESCRIPTION
There was a typo here that was originally ignored, but some other unrelated update now makes this typo matter.  The catalog status page was failing in next and on the latest develop version.  This is a hotfix just for the staging branch in prep for the production release.  We will need to propagate it back to develop and up to master.