### PR TITLE
beta testing for dataview changes (ontology download)

### DIFF
--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -36,7 +36,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.4.0
+        version: 1.5.0-beta
         cwd: src/plugin
         source:
             bower: {}


### PR DESCRIPTION
Update to the dataview plugin version in the build config to use the 1.5.0-beta tag.
We are going to try to use "-beta" ("-beta.1", etc) tags in order to test changes in CI during development of features contained in kbase dependencies. We will "promote" the tag to an unqualified version after successfully testing. This may only apply to new features which prompt a second decimal place change (e.g. 1.4.1 -> 1.5.0 in this case.). If a qualified release is updated, versioning is added like "1.5.0-beta.1", "1.5.0-beta.2".