### PR TITLE
Update travis-ci node version to 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # NB this should be 4.4, we just have to check in occasionally to see if they
   # support it yet.
-  - "4.2"
+  - "4.4"
 #cache:
 #  directories:
 #  - bower_components


### PR DESCRIPTION
This matches our development and deployment environments
It also solves a problem with installation of phantomjs -- it currently fails on 4.2, our previous node version
node 4.4 is a long term support (LTS) version.