### PR TITLE
disable data landing pages in order to get ui fixes into production.

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -79,13 +79,13 @@ plugins:
         cwd: src/plugin
         source:
             bower: {}
-    -
-        name: data-landing-pages
-        globalName: kbase-ui-plugin-data-landing-pages
-        version: 0.3.0
-        cwd: src/plugin
-        source:
-            bower: {}
+    #-
+    #    name: data-landing-pages
+    #    globalName: kbase-ui-plugin-data-landing-pages
+    #    version: 0.3.0
+    #    cwd: src/plugin
+    #    source:
+    #ß        bower: {}
     -
         name: dataapidemo
         globalName: kbase-ui-plugin-data-api-demo

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -85,7 +85,7 @@ plugins:
     #    version: 0.3.0
     #    cwd: src/plugin
     #    source:
-    #ß        bower: {}
+    #        bower: {}
     -
         name: dataapidemo
         globalName: kbase-ui-plugin-data-api-demo

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -54,13 +54,13 @@ plugins:
         cwd: src/plugin
         source:
             bower: {}
-    -
-        name: data-landing-pages
-        globalName: kbase-ui-plugin-data-landing-pages
-        version: 0.3.0
-        cwd: src/plugin
-        source:
-            bower: {}
+    #-
+    #    name: data-landing-pages
+    #    globalName: kbase-ui-plugin-data-landing-pages
+    #    version: 0.3.0
+    #    cwd: src/plugin
+    #    source:
+    #        bower: {}
     -
         name: methodview
         globalName: kbase-ui-plugin-methodview


### PR DESCRIPTION
We have a set of changes ready for deployment this week, but the data landing pages, which are enabled in the kbase-ui config, should not be used in production yet. This change simply disables the loading of the data landing pages, which allows the old Genome and Contig Set landing page widget to be invoked.