### PR TITLE
Update node_js version for travis from 4.2 to 4.4 and remove 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 sudo: false
 language: node_js
+
+# Note that travis-ci docs do not always reflect the current state of
+# node_js support. E.g. at the moment the docs say 4.2 is the latest on the 4.X 
+# branch, but it is actually 4.4
 node_js:
-  - "0.12"
-  # NB this should be 4.4, we just have to check in occasionally to see if they
-  # support it yet.
-  - "4.2"
+  - "4.4"
+  
 #cache:
 #  directories:
 #  - bower_components


### PR DESCRIPTION
This change has been made in develop, but due to changes in phantomjs,
the build fails due to an install failure for phantomjs. 4.4 fixes this.