### PR TITLE
Enable relative module paths within plugin services, pick up kbase dep updates

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -26,7 +26,7 @@ plugins:
         name: viswidgets
         globalName: kbase-ui-plugin-vis-widgets
         cwd: src/plugin
-        version: 1.1.3
+        version: 1.1.4
         source:
             bower: {}
     -
@@ -124,12 +124,12 @@ plugins:
 modules:
     -
         globalName: kbase-ui-widget
-        version: 1.0.7
+        version: 1.0.8
         source:
             bower: {}
     -
         globalName: kbase-common-js
-        version: 1.5.2
+        version: 1.6.0
         source:
             bower: {}
     -

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -23,7 +23,7 @@ plugins:
         name: viswidgets
         globalName: kbase-ui-plugin-vis-widgets
         cwd: src/plugin
-        version: 1.1.3
+        version: 1.1.4
         source:
             bower: {}
     -
@@ -78,12 +78,12 @@ plugins:
 modules:
     -
         globalName: kbase-ui-widget
-        version: 1.0.7
+        version: 1.0.8
         source:
             bower: {}
     -
         globalName: kbase-common-js
-        version: 1.5.2
+        version: 1.6.0
         source:
             bower: {}
     -

--- a/src/client/modules/app/services/widget.js
+++ b/src/client/modules/app/services/widget.js
@@ -27,9 +27,17 @@ define([
         function stop() {
             return true;
         }
-        function installWidgets(pluginConfig) {
+        function pluginHandler(widgetsConfig, pluginConfig) {
             return Promise.try(function () {
-                pluginConfig.forEach(function (widgetDef) {
+                widgetsConfig.forEach(function (widgetDef) {
+                    // If source modules are not specified, we are using module
+                    // paths. A full path will start with "plugins/" and a relative
+                    // path won't. Prefix a relative path with the plugin's module path.
+                    if (!pluginConfig.usingSourceModules) {
+                        if (!widgetDef.module.match(/^plugins\//)) {
+                            widgetDef.module = [pluginConfig.moduleRoot, widgetDef.module].join('/');
+                        }
+                    }
                     widgetManager.addWidget(widgetDef);
                 });
             });
@@ -39,7 +47,7 @@ define([
             start: start,
             stop: stop,
             // plugin interface
-            pluginHandler: installWidgets,
+            pluginHandler: pluginHandler,
             makeWidget: function () {                
                 return proxyMethod(widgetManager, 'makeWidget', arguments);
             },

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAppViewer.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAppViewer.js
@@ -11,7 +11,7 @@ define([
     'kb/service/client/narrativeMethodStore',
     'kb/service/client/catalog',
     './catalog_util',
-    'kb/widget/legacy/kbasePrompt',
+    'kb/widget/legacy/prompt',
     'kb/widget/legacy/authenticatedWidget',
     'bootstrap',
 ],


### PR DESCRIPTION
Relative module references are finally possible for widgets defined within plugins.
This was enabled by a change that creates an overall plugin config object which contains a property flagging whether modules are defined, and also the root module path for the plugin. If modules are defined, the assumption is that module ids are being used within the plugin, otherwise, module paths are. If the latter case, if the module path begins with "plugins/" it is the old-style absolute path to the plugin module directory, otherwise the module path (which looks like plugins/my-plugin/modules) is prefixed to the module path.
The dev updates are mostly related to the incorporation of new data widgets which utilize so-called legacy widget components which had previously been ported to kbase-ui, but had not been used, and the update fixes some bugs that revealed themselves.