### PR TITLE
Minor bugfix

### DIFF
--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionViewer.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionViewer.js
@@ -11,11 +11,10 @@ define([
     'kb/service/client/narrativeMethodStore',
     'kb/service/client/catalog',
     './catalog_util',
-    'kb/widget/legacy/kbasePrompt',
     'kb/widget/legacy/authenticatedWidget',
     'bootstrap',
 ],
-    function ($, Promise, NarrativeMethodStore, Catalog, CatalogUtil, KBasePrompt) {
+    function ($, Promise, NarrativeMethodStore, Catalog, CatalogUtil) {
         $.KBWidget({
             name: "KBaseCatalogFunctionViewer",
             parent: "kbaseAuthenticatedWidget",


### PR DESCRIPTION
The path the 'kb/widget/legacy/kbasePrompt' looks like it should have simply been 'kb/widget/legacy/prompt'.  For some reason though, this was working in my branch before the other changes today.  When I pulled in these changes from upstream, this bad path started throwing fatal errors breaking the new catalog function page.  But it doesn't matter because I never needed that widget to begin with.  Removing it now...