### PR TITLE
Updates for catalog function pages and admin controls

### DIFF
--- a/src/client/modules/plugins/catalog/config.yml
+++ b/src/client/modules/plugins/catalog/config.yml
@@ -332,7 +332,7 @@ install:
             path: ['catalog', 'apps', {type: param, name: namespace}, {type: param, name: id}]
             widget: catalog_app_viewer
         -
-            path: ['appcatalog', 'apps', {type: param, name: namespace}, {type: param, name: id}, {type: param, name: tag}]
+            path: ['catalog', 'apps', {type: param, name: namespace}, {type: param, name: id}, {type: param, name: tag}]
             widget: catalog_app_viewer
 
 

--- a/src/client/modules/plugins/catalog/config.yml
+++ b/src/client/modules/plugins/catalog/config.yml
@@ -348,6 +348,9 @@ install:
         -
             path: ['catalog', 'functions']
             widget: catalog_function_browser
+        -
+            path: ['catalog', 'functions', {type: param, name: tag}]
+            widget: catalog_function_browser
         -   
             path: ['catalog', 'functions', {type: param, name: module}, {type: param, name: function_id}]
             widget: catalog_function_viewer

--- a/src/client/modules/plugins/catalog/config.yml
+++ b/src/client/modules/plugins/catalog/config.yml
@@ -26,13 +26,18 @@ source:
             file: catalog_function_viewer
 
 
-
         -
             module: catalog_app_viewer
             file: catalog_app_viewer
         -
+            module: catalog_module_browser
+            file: catalog_module_browser
+        -
             module: catalog_module_viewer
             file: catalog_module_viewer
+        -
+            module: catalog_type_browser
+            file: catalog_type_browser
         -
             module: catalog_module_dev_viewer
             file: catalog_module_dev_viewer
@@ -73,8 +78,14 @@ source:
             module: catalog_app_viewer_widget
             file: widgets/kbaseCatalogAppViewer
         -
+            module: catalog_module_browser_widget
+            file: widgets/kbaseCatalogModuleBrowser
+        -
             module: catalog_module_viewer_widget
             file: widgets/kbaseCatalogModuleViewer
+        -
+            module: catalog_type_browser_widget
+            file: widgets/kbaseCatalogTypeBrowser
         -
             module: catalog_module_dev_viewer_widget
             file: widgets/kbaseCatalogModuleDevViewer
@@ -122,8 +133,16 @@ install:
             id: catalog_app_viewer
             type: factory
         - 
+            module: catalog_module_browser
+            id: catalog_module_browser
+            type: factory
+        - 
             module: catalog_module_viewer
             id: catalog_module_viewer
+            type: factory
+        - 
+            module: catalog_type_browser
+            id: catalog_type_browser
             type: factory
         - 
             module: catalog_module_dev_viewer
@@ -203,11 +222,25 @@ install:
                 jqueryName: KBaseCatalogAppViewer
             type: kbwidget
         -
+            module: catalog_module_browser_widget
+            id: catalog_module_browser_widget
+            title: Module Catalog
+            config:
+                jqueryName: KBaseCatalogModuleBrowser
+            type: kbwidget
+        -
             module: catalog_module_viewer_widget
             id: catalog_module_viewer_widget
             title: App Catalog
             config:
                 jqueryName: KBaseCatalogModuleViewer
+            type: kbwidget
+        -
+            module: catalog_type_browser_widget
+            id: catalog_type_browser_widget
+            title: Data Type Catalog
+            config:
+                jqueryName: KBaseCatalogTypeBrowser
             type: kbwidget
         -
             module: catalog_module_dev_viewer_widget
@@ -272,14 +305,17 @@ install:
     routes:
 
         -
+            path: ['catalog']
+            widget: catalog_index
+        -
             path: ['catalog','index']
             widget: catalog_index
 
 
         # module catalog
-        #-
-        #    path: ['catalog','modules']
-        #    widget: 
+        -
+            path: ['catalog','modules']
+            widget: catalog_module_browser
         -
             path: ['catalog','modules', {type: param, name: module_name}]
             widget: catalog_module_viewer
@@ -318,6 +354,12 @@ install:
         -   
             path: ['catalog', 'functions', {type: param, name: module}, {type: param, name: function_id}, {type: param, name: ver} ]
             widget: catalog_function_viewer
+
+
+        # type catalog
+        -
+            path: ['catalog','datatypes']
+            widget: catalog_type_browser
 
 
         # developer tools

--- a/src/client/modules/plugins/catalog/config.yml
+++ b/src/client/modules/plugins/catalog/config.yml
@@ -1,14 +1,17 @@
-## Welcome Panel
 ---
 package:
-    name: AppCatalog
-    description: KBase App Catalog
+    name: Catalog
+    description: KBase Catalog
     author: Michael Sneddon
     date: January 2016
-    version: 0.0.1
+    version: 0.1.0
 source:
     modules:
         # not sure what modules are, but here is one per factory
+        -
+            module: catalog_index
+            file: catalog_index
+
         -
             module: catalog_home
             file: catalog_app_browser
@@ -61,6 +64,9 @@ source:
 
         # here is one per widget
         -
+            module: catalog_index_widget
+            file: widgets/kbaseCatalogIndex
+        -
             module: catalog_home_widget
             file: widgets/kbaseCatalogBrowser
         -
@@ -103,6 +109,10 @@ source:
 install:
     # Register the welcome widget
     widgets:
+        - 
+            module: catalog_index
+            id: catalog_index
+            type: factory
         - 
             module: catalog_home
             id: catalog_home
@@ -171,6 +181,13 @@ install:
                 jqueryName: KBaseCatalogBrowser
             type: kbwidget
 
+        -
+            module: catalog_index_widget
+            id: catalog_index_widget
+            title: Catalog Index
+            config:
+                jqueryName: KBaseCatalogIndex
+            type: kbwidget
         -
             module: catalog_function_browser_widget
             id: catalog_function_browser_widget
@@ -254,19 +271,41 @@ install:
     # Set up a route to install that widget in the main body view
     routes:
 
-
-        # slowly migrate to the base url of catalog
-        #  #catalog/apps
-        #  #catalog/modules
-        #  #catalog/functions
-        #  #catalog/widgets
-        #  #catalog/services
-        #
+        -
+            path: ['catalog','index']
+            widget: catalog_index
 
 
+        # module catalog
         #-
-        #    path: ['catalog']
-        #    widget: catalog_index
+        #    path: ['catalog','modules']
+        #    widget: 
+        -
+            path: ['catalog','modules', {type: param, name: module_name}]
+            widget: catalog_module_viewer
+
+
+        # app catalog
+        -
+            path: ['catalog', 'apps']
+            widget: catalog_home
+        -
+            path: ['catalog', 'apps', {type: param, name: tag}]
+            widget: catalog_home
+        -
+            path: ['catalog', 'apps', {type: param, name: namespace}, {type: param, name: id}]
+            widget: catalog_app_viewer
+        -
+            path: ['appcatalog', 'apps', {type: param, name: namespace}, {type: param, name: id}, {type: param, name: tag}]
+            widget: catalog_app_viewer
+
+
+
+        # dynamic services catalog
+        -
+            path: ['catalog', 'services']
+            widget: catalog_service
+
 
 
         # function catalog
@@ -281,6 +320,29 @@ install:
             widget: catalog_function_viewer
 
 
+        # developer tools
+        -
+            path: ['catalog', 'register', {type: param, name: registration_id }]
+            widget: catalog_registration
+
+
+        # stats, status, admin
+        -
+            path: ['catalog', 'stats']
+            widget: catalog_stats
+        -
+            path: ['catalog', 'status']
+            widget: catalog_status
+        -
+            path: ['catalog', 'status', {type: param, name: module_names }]
+            widget: catalog_status
+        -
+            path: ['catalog', 'admin']
+            widget: catalog_admin
+
+
+
+        ##### OLD ROUTES
         -
             path: ['appcatalog']
             widget: catalog_home
@@ -293,9 +355,6 @@ install:
         -
             path: ['appcatalog', 'module', {type: param, name: module_name}]
             widget: catalog_module_viewer
-        #-
-        #    path: ['appcatalog', 'app', {type: param, name: id}]
-        #    widget: catalog_app_viewer
         -
             path: ['appcatalog', 'app', {type: param, name: namespace}, {type: param, name: id}]
             widget: catalog_app_viewer
@@ -314,7 +373,6 @@ install:
         -
             path: ['appcatalog', 'status', {type: param, name: module_names }]
             widget: catalog_status
-
         -
             path: ['appcatalog', 'service']
             widget: catalog_service

--- a/src/client/modules/plugins/catalog/modules/app_card.js
+++ b/src/client/modules/plugins/catalog/modules/app_card.js
@@ -186,7 +186,7 @@ define([
             $titleSpan.append($('<div>').addClass('kbcb-app-card-title').append(info.name));
             if(info['module_name']) {
                 $titleSpan.append($('<div>').addClass('kbcb-app-card-module').append(
-                                        $('<a href="#appcatalog/module/'+info.module_name+'">')
+                                        $('<a href="#catalog/modules/'+info.module_name+'">')
                                             .append(info.module_name)
                                             .on('click',function(event) {
                                                 // have to stop propagation so we don't go to the app page first
@@ -294,13 +294,13 @@ define([
                         // module name right now is encoded in the ID
                         //window.location.href = '#appcatalog/app/'.info.module_name+'/'+app.info.id;
                         if(tag) {
-                            window.location.href = '#appcatalog/app/'+info.id + '/'+tag;
+                            window.location.href = '#catalog/apps/'+info.id + '/'+tag;
                         } else {
-                            window.location.href = '#appcatalog/app/'+info.id;
+                            window.location.href = '#catalog/apps/'+info.id;
                         }
                     } else {
                         // legacy method, encoded as l.m
-                        window.location.href = '#appcatalog/app/l.m/'+info.id;
+                        window.location.href = '#catalog/apps/l.m/'+info.id;
                     }
                 } else {
                     // apps still go to old style page

--- a/src/client/modules/plugins/catalog/modules/catalog_admin.js
+++ b/src/client/modules/plugins/catalog/modules/catalog_admin.js
@@ -42,7 +42,7 @@ define([
             });
         }
         function attach(node) {
-            runtime.send('ui', 'setTitle', 'App Catalog');
+            runtime.send('ui', 'setTitle', 'Catalog Admin');
             return Promise.try(function () {
                 mount = node;
                 container = mount.appendChild(DOM.createElement('div'));

--- a/src/client/modules/plugins/catalog/modules/catalog_index.js
+++ b/src/client/modules/plugins/catalog/modules/catalog_index.js
@@ -1,0 +1,99 @@
+/*global
+ define
+ */
+/*jslint
+ browser: true,
+ white: true
+ */
+define([
+    'bluebird',
+    'kb/common/dom',
+    'kb/common/html',
+    'kb/widget/widgetSet'
+], function (Promise, DOM, html, WidgetSet) {
+    'use strict';
+    function widget(config) {
+        var mount, container, runtime = config.runtime,
+            widgetSet = WidgetSet.make({runtime: runtime}),
+            layout;
+
+        // Mini widget manager
+        // TODO: the jquery name should be stored in the widget definition not here.
+        function render() {
+
+            // the catalog home page is simple the catalog browser
+            var div=html.tag('div');
+            return div({
+                id: widgetSet.addWidget('catalog_index_widget', 
+                    {
+                        jqueryName: 'KBaseCatalogIndex', 
+                        jquery_name:'KBaseCatalogIndex'
+                    })
+            });
+        }
+
+        layout = render();
+
+        // Widget Interface Implementation
+
+        function init(config) {
+            return Promise.try(function () {
+                return widgetSet.init(config);
+            });
+        }
+        function attach(node) {
+            runtime.send('ui', 'setTitle', 'Catalog Index');
+            return Promise.try(function () {
+                mount = node;
+                container = mount.appendChild(DOM.createElement('div'));
+                container.innerHTML = layout;
+                // mount.appendChild(container);
+                return widgetSet.attach();
+            });
+        }
+        function start(params) {
+            return Promise.try(function () {
+                return widgetSet.start(params);
+            });
+        }
+        function run(params) {
+            return Promise.try(function () {
+                return widgetSet.run(params);
+            });
+        }
+        function stop() {
+            return Promise.try(function () {
+                return widgetSet.stop();
+            });
+        }
+        function detach() {
+            runtime.send('ui', 'setTitle', '');
+            return Promise.try(function () {
+                return widgetSet.detach();
+            });
+        }
+        function destroy() {
+            return Promise.try(function () {
+                return widgetSet.destroy();
+            });
+        }
+
+        // Widget Interface
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run,
+            stop: stop,
+            detach: detach,
+            destroy: destroy
+        };
+    }
+
+    return {
+        make: function (config) {
+            return widget(config);
+        }
+    };
+
+});

--- a/src/client/modules/plugins/catalog/modules/catalog_module_browser.js
+++ b/src/client/modules/plugins/catalog/modules/catalog_module_browser.js
@@ -24,10 +24,10 @@ define([
             // the catalog home page is simple the catalog browser
             var div=html.tag('div');
             return div({
-                id: widgetSet.addWidget('catalog_module_dev_viewer_widget', 
+                id: widgetSet.addWidget('catalog_module_browser_widget', 
                     {
-                        jqueryName: 'KBaseCatalogModuleDevViewer', 
-                        jquery_name:'KBaseCatalogModuleDevViewer'
+                        jqueryName: 'KBaseModuleBrowser', 
+                        jquery_name:'KBaseModuleBrowser'
                     })
             });
         }

--- a/src/client/modules/plugins/catalog/modules/catalog_module_viewer.js
+++ b/src/client/modules/plugins/catalog/modules/catalog_module_viewer.js
@@ -42,7 +42,7 @@ define([
             });
         }
         function attach(node) {
-            runtime.send('ui', 'setTitle', 'App Catalog');
+            runtime.send('ui', 'setTitle', 'Module Catalog');
             return Promise.try(function () {
                 mount = node;
                 container = mount.appendChild(DOM.createElement('div'));

--- a/src/client/modules/plugins/catalog/modules/catalog_registration.js
+++ b/src/client/modules/plugins/catalog/modules/catalog_registration.js
@@ -42,7 +42,7 @@ define([
             });
         }
         function attach(node) {
-            runtime.send('ui', 'setTitle', 'App Catalog');
+            runtime.send('ui', 'setTitle', 'Catalog Module Registration');
             return Promise.try(function () {
                 mount = node;
                 container = mount.appendChild(DOM.createElement('div'));

--- a/src/client/modules/plugins/catalog/modules/catalog_service.js
+++ b/src/client/modules/plugins/catalog/modules/catalog_service.js
@@ -42,7 +42,7 @@ define([
             });
         }
         function attach(node) {
-            runtime.send('ui', 'setTitle', 'App Catalog');
+            runtime.send('ui', 'setTitle', 'Service Catalog');
             return Promise.try(function () {
                 mount = node;
                 container = mount.appendChild(DOM.createElement('div'));

--- a/src/client/modules/plugins/catalog/modules/catalog_status.js
+++ b/src/client/modules/plugins/catalog/modules/catalog_status.js
@@ -42,7 +42,7 @@ define([
             });
         }
         function attach(node) {
-            runtime.send('ui', 'setTitle', 'App Catalog');
+            runtime.send('ui', 'setTitle', 'Catalog Status');
             return Promise.try(function () {
                 mount = node;
                 container = mount.appendChild(DOM.createElement('div'));

--- a/src/client/modules/plugins/catalog/modules/catalog_type_browser.js
+++ b/src/client/modules/plugins/catalog/modules/catalog_type_browser.js
@@ -24,10 +24,10 @@ define([
             // the catalog home page is simple the catalog browser
             var div=html.tag('div');
             return div({
-                id: widgetSet.addWidget('catalog_module_dev_viewer_widget', 
+                id: widgetSet.addWidget('catalog_type_browser_widget', 
                     {
-                        jqueryName: 'KBaseCatalogModuleDevViewer', 
-                        jquery_name:'KBaseCatalogModuleDevViewer'
+                        jqueryName: 'KBaseCatalogTypeBrowser', 
+                        jquery_name:'KBaseCatalogTypeBrowser'
                     })
             });
         }
@@ -42,7 +42,7 @@ define([
             });
         }
         function attach(node) {
-            runtime.send('ui', 'setTitle', 'Module Catalog');
+            runtime.send('ui', 'setTitle', 'Data Type Catalog');
             return Promise.try(function () {
                 mount = node;
                 container = mount.appendChild(DOM.createElement('div'));

--- a/src/client/modules/plugins/catalog/modules/function_card.js
+++ b/src/client/modules/plugins/catalog/modules/function_card.js
@@ -170,7 +170,7 @@ define([
                 }
             }
             $titleSpan.append($('<div>').addClass('kbcb-app-card-module').css({'padding-top':'4px'}).append(
-                                    $('<a href="#appcatalog/module/'+info.module_name+'">')
+                                    $('<a href="#catalog/modules/'+info.module_name+'">')
                                         .append(info.module_name)
                                         .on('click',function(event) {
                                             // have to stop propagation so we don't go to the app page first

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAdmin.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAdmin.js
@@ -644,7 +644,7 @@ define([
 
 
                 var $moduleName = $('<input type="text" size="50" placeholder="ModuleName">').addClass('form-control').css('margin','4px');
-                var $appId = $('<input type="text" size="50" placeholder="app_id">').addClass('form-control').css('margin','4px');
+                var $functionName = $('<input type="text" size="50" placeholder="function_name">').addClass('form-control').css('margin','4px');
                 var $clientGroup = $('<input type="text" size="50" placeholder="client_group_name">').addClass('form-control').css('margin','4px');
 
                 var volumeMountEntry = []; var nOptions = 4;
@@ -677,7 +677,7 @@ define([
                 $modifyVolMount
                     .append($('<div>').addClass('input-group').css('width','35%')
                                 .append($moduleName)
-                                .append($appId)
+                                .append($functionName)
                                 .append($clientGroup))
                     .append($volMountInfo)
                     .append($modify)
@@ -688,7 +688,7 @@ define([
                         'volume_mounts':[]
                     }
                     if($moduleName.val()) { config['module_name'] = $moduleName.val() }
-                    if($appId.val()) { config['app_id'] = $appId.val() }
+                    if($functionName.val()) { config['function_name'] = $functionName.val() }
                     if($clientGroup.val()) { config['client_group'] = $clientGroup.val() }
 
                     for(var v=0; v<volumeMountEntry.length; v++) {
@@ -721,7 +721,7 @@ define([
                 $tbl.append(
                     $('<tr>')
                         .append($('<th>').append('<b>Module Name</b>'))
-                        .append($('<th>').append('<b>App ID</b>'))
+                        .append($('<th>').append('<b>Function Name</b>'))
                         .append($('<th>').append('<b>Client Group</b>'))
                         .append($('<th>').append('<b>Host Directory &nbsp;&nbsp;<i class="fa fa-arrow-right"></i>&nbsp;&nbsp; Container Directory</b>'))
                         .append($('<th>')));
@@ -730,7 +730,7 @@ define([
                     var vm = self.volume_mounts[k];
 
                     var module_name = vm['module_name'];
-                    var app_id = vm['app_id'];
+                    var function_name = vm['function_name'];
                     var client_group = vm['client_group'];
 
                     var volMountStr = '';
@@ -752,10 +752,10 @@ define([
                         return function() {
                             var confirm = window.confirm("Are you sure you want to remove this volume mount?");
                             if (confirm == true) {
-                                console.log('removing: '+vm['module_name'] + ' - ' + vm['app_id'] + ' - ' + vm['client_group']);
+                                console.log('removing: '+vm['module_name'] + ' - ' + vm['function_name'] + ' - ' + vm['client_group']);
                                 self.catalog.remove_volume_mount({
                                             'module_name':vm['module_name'],
-                                            'app_id':vm['app_id'],
+                                            'function_name':'', //vm['function_name'],
                                             'client_group':vm['client_group']
                                         })
                                         .then(function () {
@@ -778,7 +778,7 @@ define([
                             .append($('<td>')
                                 .append($('<a href="#appcatalog/module/'+module_name+'">').append(module_name)))
                             .append($('<td>')
-                                .append($('<a href="#appcatalog/app/'+app_id+'">').append(app_id)))
+                                .append(function_name))
                             .append($('<td>')
                                 .append(client_group))
                             .append($('<td>')

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAdmin.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAdmin.js
@@ -62,6 +62,7 @@ define([
                 self.$devListDiv = mainPanelElements[3];
                 self.$moduleList = mainPanelElements[4];
                 self.$clientGroupList = mainPanelElements[5];
+                self.$volumeMountList = mainPanelElements[6];
                 self.$elem.append(self.$mainPanel);
                 self.showLoading();
 
@@ -80,8 +81,19 @@ define([
 
                 // when we have it all, then render the list
                 Promise.all(loadingCalls).then(function() {
-                    self.render();
-                    self.hideLoading();
+
+                    if(self.isAdmin) {
+                        var adminCalls = [];
+                        adminCalls.push(self.getVolumeMounts())
+                        Promise.all(adminCalls).then(function(){
+                            self.render();
+                            self.hideLoading();
+                        });
+                    } else {
+                        self.render();
+                        self.hideLoading();
+                    }
+
                 });
 
                 return this;
@@ -94,6 +106,7 @@ define([
                 self.renderDevList();
                 self.renderModuleList();
                 self.renderClientGroupList();
+                self.renderVolumeMountList();
             },
 
 
@@ -102,6 +115,7 @@ define([
                     this.runtime.getConfig('services.catalog.url'),
                     { token: this.runtime.service('session').getAuthToken() }
                 );
+                console.log(this.catalog)
                 this.nms = new NarrativeMethodStore(
                     this.runtime.getConfig('services.narrative_method_store.url'),
                     { token: this.runtime.service('session').getAuthToken() }
@@ -139,11 +153,15 @@ define([
                 $mainPanel.append($clientGroups);
                 $mainPanel.append('<br>');
 
+                $mainPanel.append($('<h4>').append('Volume Mounts:'));
+                var $volumeMounts = $('<div>');
+                $mainPanel.append($volumeMounts);
+                $mainPanel.append('<br>');
 
 
                 $mainPanel.append('<br><br>');
 
-                return [$mainPanel, $basicStatusDiv, $pendingReleaseDiv, $approvedDevelopers, $moduleList, $clientGroups];
+                return [$mainPanel, $basicStatusDiv, $pendingReleaseDiv, $approvedDevelopers, $moduleList, $clientGroups, $volumeMounts];
             },
 
             initLoadingPanel: function() {
@@ -336,7 +354,7 @@ define([
 
                 self.$pendingReleaseDiv.append(
                     $('<button>').addClass('btn btn-default').css('margin','12px')
-                            .append($('<i>').addClass('fa fa-refresh').append(' Refresh'))
+                            .append($('<i>').addClass('fa fa-refresh')).append(' Refresh')
                             .on('click', function() { self.rerenderPendingRelease(); })
                     );
 
@@ -600,6 +618,179 @@ define([
 
 
 
+            refreshVolumeMounts: function() {
+                var self = this;
+                self.$volumeMountList.empty();
+                return self.getVolumeMounts()
+                    .then(function() {
+                        self.renderVolumeMountList();
+                    });
+            },
+
+            renderVolumeMountList: function() {
+                var self = this;
+
+                if(!self.isAdmin) {
+                    self.$volumeMountList.append($('<div>').css('margin','1em').append('Only Admins can view volume mounts.'));
+                    return;
+                }
+
+                var $modifyVolMount = $('<div>').css('margin','1em');
+                var $volumeMountList = $('<div>').css('margin','1em');
+
+
+                self.$volumeMountList.append($modifyVolMount);
+                self.$volumeMountList.append($volumeMountList);
+
+
+                var $moduleName = $('<input type="text" size="50" placeholder="ModuleName">').addClass('form-control').css('margin','4px');
+                var $appId = $('<input type="text" size="50" placeholder="app_id">').addClass('form-control').css('margin','4px');
+                var $clientGroup = $('<input type="text" size="50" placeholder="client_group_name">').addClass('form-control').css('margin','4px');
+
+                var volumeMountEntry = []; var nOptions = 4;
+                for(var x=0; x<nOptions; x++ ){
+                    volumeMountEntry.push({
+                        '$host_dir':  $('<input type="text" size="50" placeholder="/my/host/path/'+(x+1)+'">').addClass('form-control').css('margin','4px'),
+                        '$con_dir' :  $('<input type="text" size="50" placeholder="/my/container/path/'+(x+1)+'">').addClass('form-control').css('margin','4px'),
+                        '$rw'      :  $('<select>').addClass('form-control').css('margin','4px')
+                                        .append($('<option value="1">').append('Read-only'))
+                                        .append($('<option value="0">').append('Read/Write'))
+                    });
+                }
+
+                var $modify = $('<button>').addClass('btn btn-default').append($('<i>').addClass('fa fa-plus')).append(' Submit Entry').css('margin-left','10px');
+
+                var $result = $('<div>').css('margin','1em');
+
+                $modifyVolMount.append($('<b>').append('Add / Modify Volume Mounts:')).append(' (use the API if you need more than '+nOptions+' mounts)').append('<br>')
+
+                var $volMountInfo = $('<div>');
+                for (var x=0; x<volumeMountEntry.length; x++) {
+                    var $d = $('<div>').addClass('row');
+                    $d.append($('<div>').addClass('col-md-1').append());
+                    $d.append($('<div>').addClass('col-md-3').append(volumeMountEntry[x]['$host_dir']));
+                    $d.append($('<div>').addClass('col-md-3').append(volumeMountEntry[x]['$con_dir']));
+                    $d.append($('<div>').addClass('col-md-2').append(volumeMountEntry[x]['$rw']));
+                    $volMountInfo.append($d);
+                }
+
+                $modifyVolMount
+                    .append($('<div>').addClass('input-group').css('width','35%')
+                                .append($moduleName)
+                                .append($appId)
+                                .append($clientGroup))
+                    .append($volMountInfo)
+                    .append($modify)
+                    .append($result);
+
+                $modify.on('click', function() {
+                    var config = {
+                        'volume_mounts':[]
+                    }
+                    if($moduleName.val()) { config['module_name'] = $moduleName.val() }
+                    if($appId.val()) { config['app_id'] = $appId.val() }
+                    if($clientGroup.val()) { config['client_group'] = $clientGroup.val() }
+
+                    for(var v=0; v<volumeMountEntry.length; v++) {
+                        var vme = volumeMountEntry[v];
+                        if(vme['$host_dir'].val() && vme['$con_dir'].val()) {
+                            config['volume_mounts'].push({
+                                'host_dir': vme['$host_dir'].val(),
+                                'container_dir': vme['$con_dir'].val(),
+                                'read_only': vme['$rw'].val()
+                            });
+                        }
+                    }
+
+                    self.catalog.set_volume_mount(config)
+                        .then(function () {
+                            $result.empty();
+                            return self.refreshVolumeMounts();
+                        })
+                        .catch(function (err) {
+                            $result.empty();
+                            console.error('ERROR');
+                            console.error(err);
+                            $result.prepend($('<div role=alert>').addClass('alert alert-danger')
+                                .append('<b>Error:</b> '+err.error.message));
+                        })
+                });
+
+
+                var $tbl = $('<table>').addClass('table table-hover table-condensed');
+                $tbl.append(
+                    $('<tr>')
+                        .append($('<th>').append('<b>Module Name</b>'))
+                        .append($('<th>').append('<b>App ID</b>'))
+                        .append($('<th>').append('<b>Client Group</b>'))
+                        .append($('<th>').append('<b>Host Directory &nbsp;&nbsp;<i class="fa fa-arrow-right"></i>&nbsp;&nbsp; Container Directory</b>'))
+                        .append($('<th>')));
+
+                for(var k=0; k<self.volume_mounts.length; k++) {
+                    var vm = self.volume_mounts[k];
+
+                    var module_name = vm['module_name'];
+                    var app_id = vm['app_id'];
+                    var client_group = vm['client_group'];
+
+                    var volMountStr = '';
+                    if(vm['volume_mounts'].length == 0) { volMountStr = 'None.'}
+                    for(var i=0; i<vm['volume_mounts'].length; i++) {
+                        if(i>0) { volMountStr += '<br>'}
+                        volMountStr += vm['volume_mounts'][i]['host_dir'] + ' &nbsp;&nbsp;<i class="fa fa-arrow-right"></i>&nbsp;&nbsp; ';
+                        volMountStr += vm['volume_mounts'][i]['container_dir'];
+                        if(vm['volume_mounts'][i]['read_only'] == 1) {
+                            volMountStr += ' &nbsp; (read-only)';
+                        } else {
+                            volMountStr += ' &nbsp; (r/w)';
+                        }
+                    }
+
+                    var $trash = $('<span>').css('cursor','pointer').append($('<i class="fa fa-trash-o" aria-hidden="true">'));
+                    
+                    $trash.on('click', (function(vm) {
+                        return function() {
+                            var confirm = window.confirm("Are you sure you want to remove this volume mount?");
+                            if (confirm == true) {
+                                console.log('removing: '+vm['module_name'] + ' - ' + vm['app_id'] + ' - ' + vm['client_group']);
+                                self.catalog.remove_volume_mount({
+                                            'module_name':vm['module_name'],
+                                            'app_id':vm['app_id'],
+                                            'client_group':vm['client_group']
+                                        })
+                                        .then(function () {
+                                            $result.empty();
+                                            return self.refreshVolumeMounts();
+                                        })
+                                        .catch(function (err) {
+                                            $result.empty();
+                                            console.error('ERROR');
+                                            console.error(err);
+                                            $result.prepend($('<div role=alert>').addClass('alert alert-danger')
+                                                .append('<b>Error:</b> '+err.error.message));
+                                        });
+                            }
+                        }
+                    }(vm)));
+
+                    $tbl.append(
+                        $('<tr>')
+                            .append($('<td>')
+                                .append($('<a href="#appcatalog/module/'+module_name+'">').append(module_name)))
+                            .append($('<td>')
+                                .append($('<a href="#appcatalog/app/'+app_id+'">').append(app_id)))
+                            .append($('<td>')
+                                .append(client_group))
+                            .append($('<td>')
+                                .append(volMountStr))
+                            .append($('<td>')
+                                .append($trash)));
+                }
+                $volumeMountList.append($tbl);
+            },
+
+
+
             getCatalogVersion: function() {
                 var self = this
 
@@ -671,6 +862,19 @@ define([
                         });
 
                         self.client_groups = non_empty_groups;
+                    })
+                    .catch(function (err) {
+                        console.error('ERROR');
+                        console.error(err);
+                    });
+            },
+
+            getVolumeMounts: function() {
+                var self = this
+                self.volume_mounts = [];
+                return self.catalog.list_volume_mounts({})
+                    .then(function (mounts) {
+                        self.volume_mounts = mounts;
                     })
                     .catch(function (err) {
                         console.error('ERROR');

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAdmin.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAdmin.js
@@ -22,7 +22,6 @@ define([
 
             // clients to the catalog service and the NarrativeMethodStore
             catalog: null,
-            nms: null,
             util: null,
 
             // main panel and elements
@@ -115,18 +114,13 @@ define([
                     this.runtime.getConfig('services.catalog.url'),
                     { token: this.runtime.service('session').getAuthToken() }
                 );
-                console.log(this.catalog)
-                this.nms = new NarrativeMethodStore(
-                    this.runtime.getConfig('services.narrative_method_store.url'),
-                    { token: this.runtime.service('session').getAuthToken() }
-                );
             },
 
             initMainPanel: function($appListPanel, $moduleListPanel) {
                 var $mainPanel = $('<div>').addClass('container');
 
                 $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#catalog/apps">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog Index')));
                 
                 $mainPanel.append($('<h3>').append('Catalog Admin Console:'));
 
@@ -583,7 +577,7 @@ define([
                         }
                     }
 
-                    self.catalog.set_client_group_configuration( { module_name:moduleName, function_name:functionName, client_groups:groupsList } )
+                    self.catalog.set_client_group_config( { module_name:moduleName, function_name:functionName, client_groups:groupsList } )
                         .then(function () {
                             $result.empty();
                             return self.refreshClientGroups();
@@ -598,6 +592,13 @@ define([
 
 
                 var $tbl = $('<table>').addClass('table table-hover table-condensed');
+                $tbl.append(
+                    $('<tr>')
+                        .append($('<th>').append('<b>Module Name</b>'))
+                        .append($('<th>').append('<b>Function Name</b>'))
+                        .append($('<th>').append('<b>Client Groups</b>'))
+                        .append($('<th>')));
+
                 for(var k=0; k<self.client_groups.length; k++) {
 
                     // loop to get client group string
@@ -611,10 +612,8 @@ define([
                     
                     $trash.on('click', (function(cg) {
                         return function() {
-                                console.log('removing: '+cg['module_name'] + ' - "' + cg['function_name']);
                             var confirm = window.confirm("Are you sure you want to remove this client group configuration?");
                             if (confirm == true) {
-                                console.log('removing: '+cg['module_name'] + ' - "' + cg['function_name']);
                                 self.catalog.remove_client_group_config({
                                             'module_name':cg['module_name'],
                                             'function_name':cg['function_name']
@@ -763,7 +762,6 @@ define([
 
                 for(var k=0; k<self.volume_mounts.length; k++) {
                     var vm = self.volume_mounts[k];
-                    console.log(vm)
 
                     var module_name = vm['module_name'];
                     var function_name = vm['function_name'];
@@ -788,7 +786,6 @@ define([
                         return function() {
                             var confirm = window.confirm("Are you sure you want to remove this volume mount?");
                             if (confirm == true) {
-                                console.log('removing: '+vm['module_name'] + ' - "' + vm['function_name'] + '"" - ' + vm['client_group']);
                                 self.catalog.remove_volume_mount({
                                             'module_name':vm['module_name'],
                                             'function_name':vm['function_name'],
@@ -882,22 +879,9 @@ define([
             getClientGroups: function() {
                 var self = this
                 self.client_groups = [];
-                return self.catalog.get_client_groups({})
+                return self.catalog.list_client_group_configs({})
                     .then(function (groups) {
-
-                        var non_empty_groups = [];
-                        for(var k=0; k<groups.length; k++) {
-                            if(groups[k].client_groups.length>0) {
-                                non_empty_groups.push(groups[k]);
-                            }
-                        }
-                        non_empty_groups.sort(function(a,b) {
-                            if(a.app_id < b.app_id) return -1;
-                            if(a.app_id > b.app_id) return 1;
-                            return 0;
-                        });
-
-                        self.client_groups = non_empty_groups;
+                        self.client_groups = groups;
                     })
                     .catch(function (err) {
                         console.error('ERROR');

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAppViewer.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAppViewer.js
@@ -255,7 +255,7 @@ define([
                 var $infoPanel = $('<div>').css('margin','1em');
 
                 $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#appcatalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog/apps">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
                 
                 $mainPanel
                     .append($header)
@@ -831,7 +831,7 @@ define([
 
                 if(self.moduleDetails.info) {
                     $titleSpan.append($('<div>').addClass('kbcb-app-page-module').append(
-                                            $('<a href="#appcatalog/module/'+self.moduleDetails.info.module_name+'">')
+                                            $('<a href="#catalog/modules/'+self.moduleDetails.info.module_name+'">')
                                                 .append(self.moduleDetails.info.module_name)));
                 }
 

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogBrowser.js
@@ -235,9 +235,9 @@ define([
 
 
                 // ORGANIZE BY
-                var $verR = $('<a href="#appcatalog/browse/release">').append('Released Modules');
-                var $verB = $('<a href="#appcatalog/browse/beta">').append('Beta Modules');
-                var $verD = $('<a href="#appcatalog/browse/dev">').append('Modules in Development');
+                var $verR = $('<a href="#catalog/apps/release">').append('Released Modules');
+                var $verB = $('<a href="#catalog/apps/beta">').append('Beta Modules');
+                var $verD = $('<a href="#catalog/apps/dev">').append('Modules in Development');
 
                 var $version = $('<li>').addClass('dropdown')
                                     .append('<a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Version<span class="caret"></span></a>')
@@ -253,9 +253,9 @@ define([
 
 
                 // NAV LINKS
-                var $statusLink = $('<li>').append($('<a href="#appcatalog/status">').append('Status'));
+                var $statusLink = $('<li>').append($('<a href="#catalog/status">').append('Status'));
 
-                var $registerLink = $('<li>').append($('<a href="#appcatalog/register">').append('<i class="fa fa-plus-circle"></i> Add Module'));
+                var $registerLink = $('<li>').append($('<a href="#catalog/register">').append('<i class="fa fa-plus-circle"></i> Add Module'));
 
 
 
@@ -727,7 +727,7 @@ define([
                             var $section = $('<div>').addClass('catalog-section');
                             $currentModuleDiv = $('<div>').addClass('kbcb-app-card-list-container');
                             $section.append($('<div>').css({'color':'#777'})
-                                    .append($('<h4>').append('<a href="#appcatalog/module/'+m+'">'+m+'</a>')));
+                                    .append($('<h4>').append('<a href="#catalog/modules/'+m+'">'+m+'</a>')));
                             $section.append($currentModuleDiv);
                             self.$appListPanel.append($section);
                         }

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogBrowser.js
@@ -257,6 +257,8 @@ define([
 
                 var $registerLink = $('<li>').append($('<a href="#catalog/register">').append('<i class="fa fa-plus-circle"></i> Add Module'));
 
+                var $helpLink = $('<li>').append($('<a href="#catalog">').append('<i class="fa fa-question-circle"></i> Help'));
+
 
 
                 // PLACE CONTENT ON CONTROL BAR
@@ -265,7 +267,8 @@ define([
                         .append($organizeBy)
                         .append($version)
                         .append($statusLink)
-                        .append($registerLink));
+                        .append($registerLink)
+                        .append($helpLink));
 
                 $nav.append($container)
 
@@ -666,6 +669,15 @@ define([
 
                 self.$appListPanel.children().detach();
 
+                if(self.options.tag) {
+                    var text_css = {'color':'#777', 'font-size':'1.1em', 'margin':'5px' }
+                    if(self.options.tag == 'dev') {
+                        self.$appListPanel.append($('<div>').css(text_css).append('Currently viewing Apps under development.'));
+                    } else if (self.options.tag == 'beta') {
+                        self.$appListPanel.append($('<div>').css(text_css).append('Currently viewing Apps in beta.'));
+                    }
+                }
+
                 // no organization, so show all
                 if(!organizeBy) { return; }
 
@@ -779,7 +791,6 @@ define([
                             $noAuthorDiv.append(self.appList[k].getNewCardDiv())
                         }
                     }
-
                 }
 
                 

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionBrowser.js
@@ -197,9 +197,9 @@ define([
 
 
                 // NAV LINKS
-                var $statusLink = $('<li>').append($('<a href="#appcatalog/status">').append('Status'));
+                var $statusLink = $('<li>').append($('<a href="#catalog/status">').append('Status'));
 
-                var $registerLink = $('<li>').append($('<a href="#appcatalog/register">').append('<i class="fa fa-plus-circle"></i> Add Module'));
+                var $registerLink = $('<li>').append($('<a href="#catalog/register">').append('<i class="fa fa-plus-circle"></i> Add Module'));
 
 
 
@@ -579,7 +579,7 @@ define([
                             var $section = $('<div>').addClass('catalog-section');
                             $currentModuleDiv = $('<div>').addClass('kbcb-app-card-list-container');
                             $section.append($('<div>').css({'color':'#777'})
-                                    .append($('<h4>').append('<a href="#appcatalog/module/'+m+'">'+m+'</a>')));
+                                    .append($('<h4>').append('<a href="#catalog/modules/'+m+'">'+m+'</a>')));
                             $section.append($currentModuleDiv);
                             self.$functionListPanel.append($section);
                         }
@@ -710,7 +710,6 @@ define([
                     var types = [];
                     for(var k in self.inputTypes) { types.push(k); }
                     types.sort();
-                    console.log(self.inputTypes)
 
                     // create the sections per author
                     var $typeDivLookup = {};

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionBrowser.js
@@ -87,7 +87,17 @@ define([
 
                 // Default sort is by name
                 self.organizeBy = 'name_az';
-                self.switchVersion('release')
+
+                if(self.options.tag) {
+                    self.tag = self.options.tag;
+                    if(self.tag!=='dev' && self.tag!=='beta' && self.tag!=='release') {
+                        console.warn('tag '+tag+ ' is not valid! Use: dev/beta/release.  defaulting to release.');
+                        self.tag='release';
+                    }
+                    self.switchVersion(self.tag);
+                } else {
+                    self.switchVersion('release');
+                }
                 
                 return this;
             },
@@ -201,6 +211,7 @@ define([
 
                 var $registerLink = $('<li>').append($('<a href="#catalog/register">').append('<i class="fa fa-plus-circle"></i> Add Module'));
 
+                var $helpLink = $('<li>').append($('<a href="#catalog">').append('<i class="fa fa-question-circle"></i> Help'));
 
 
                 // PLACE CONTENT ON CONTROL BAR
@@ -209,7 +220,8 @@ define([
                         .append($organizeBy)
                         .append($version)
                         .append($statusLink)
-                        .append($registerLink));
+                        .append($registerLink)
+                        .append($helpLink));
 
                 $nav.append($container)
 
@@ -221,6 +233,7 @@ define([
                 self.showLoading();
                 var loadingCalls = [];
                 self.functionList = [];
+                self.tag = tag;
                 loadingCalls.push(self.refreshLocalFunctionList(tag));
 
                 Promise.all(loadingCalls).then(function() {
@@ -357,7 +370,6 @@ define([
 
                 return self.catalog.list_local_functions(localFunctionSelection)
                     .then(function (functions) {
-                        console.log(functions)
 
                         /*functions.push({
                             'module_name': 'ModuleName',
@@ -511,6 +523,17 @@ define([
                 var organizeBy = self.organizeBy;
 
                 self.$functionListPanel.children().detach();
+
+                if(self.tag) {
+                    var text_css = {'color':'#777', 'font-size':'1.1em', 'margin':'5px' }
+                    if(self.tag == 'dev') {
+                        self.$functionListPanel.append($('<div>').css(text_css).append('Currently viewing Functions under development.'));
+                    } else if (self.tag == 'beta') {
+                        self.$functionListPanel.append($('<div>').css(text_css).append('Currently viewing Functions in beta.'));
+                    }
+                }
+
+
 
                 if(self.functionList.length === 0) {
                     var $listContainer = $('<div>').css({'overflow':'auto', 'padding':'0 0 2em 0'});

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionViewer.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionViewer.js
@@ -233,7 +233,7 @@ define([
                 
 
                 $titleSpan.append($('<div>').addClass('kbcb-app-page-module').append(
-                                        $('<a href="#appcatalog/module/'+info.module_name+'">')
+                                        $('<a href="#catalog/modules/'+info.module_name+'">')
                                             .append(info.module_name)));
 
 
@@ -443,8 +443,17 @@ define([
 
                         self.$paramsPanel.append(code);
                     }
+
+/*                  if(self.module_version) {
+                        if(self.module_version.compilation_report) {
+                            if(self.module_version.compilation_report) {
+                                console.log(self.module_version)
+                            }
+                        }
+                    }*/
                     
                 }
+
 
 
 

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogIndex.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogIndex.js
@@ -56,8 +56,13 @@ define([
                 var base = '#catalog/';
 
 
-                var descriptionText = 'Browse and search for Narrative Apps.  This is probably what you are looking for.';
+                var descriptionText = 'Browse and search for KBase apps.  This is probably what you are looking for.';
                 $m.append($('<h4>').append(self.makeLink(base+'apps', 'App Catalog')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
+
+                var descriptionText = 'A brief introduction to KBase apps and the App Catalog.';
+                $m.append($('<h4>').append(self.makeLink('https://kbase.us/apps', 'App Catalog Help Pages')))
                   .append($('<div>').append(descriptionText));
                 $m.append('<hr>');
 
@@ -102,7 +107,7 @@ define([
                 $m.append('<hr>');
 
 
-                descriptionText = 'View summary statistics of Narrative Apps.';
+                descriptionText = 'View summary statistics of KBase Apps.';
                 $m.append($('<h4>').append(self.makeLink(base+'stats', 'Catalog Stats')))
                   .append($('<div>').append(descriptionText));
                 $m.append('<hr>');

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogIndex.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogIndex.js
@@ -7,13 +7,12 @@
  */
 define([
     'jquery',
-    'kb/service/client/narrativeMethodStore',
     'kb/service/client/catalog',
     './catalog_util',
     'kb/widget/legacy/authenticatedWidget',
     'bootstrap',
 ],
-    function ($, NarrativeMethodStore, Catalog, CatalogUtil) {
+    function ($, Catalog, CatalogUtil) {
         $.KBWidget({
             name: "KBaseCatalogIndex",
             parent: "kbaseAuthenticatedWidget",  // todo: do we still need th
@@ -22,21 +21,10 @@ define([
 
             // clients to the catalog service and the NarrativeMethodStore
             catalog: null,
-            nms: null,
             util: null,
 
             // main panel and elements
             $mainPanel: null,
-            $loadingPanel: null,
-            $basicStatusDiv: null,
-            $pendingReleaseDiv: null,
-            $devListDiv: null,
-
-
-            build_list: null,
-            module_list: null,
-            catalog_version: null,
-            requested_releases: null,
 
             isAdmin: null,
 
@@ -74,48 +62,48 @@ define([
                 $m.append('<hr>');
 
 
-                descriptionText = 'View the list of registered KBase Modules.  Modules are groups of related Apps, code, functions, data and other components'
+                descriptionText = 'View registered KBase Modules.  Modules are groups of related Apps, code, functions, data and other components'
                                     + ' registered from a single git repository by developers using the KBase SDK.';
                 $m.append($('<h4>').append(self.makeLink(base+'modules', 'Module Catalog')))
                   .append($('<div>').append(descriptionText));
                 $m.append('<hr>');
 
 
-                descriptionText = '(for developers) Browse and search functions that you can call from your code.  Think of it as your KBase API library that any developer can contribute to.'
+                descriptionText = '(for developers) Browse and search for functions that you can call from your code.  Think of these functions as your KBase API library that anyone can contribute to.'
                 $m.append($('<h4>').append(self.makeLink(base+'functions', 'Function Catalog')))
                   .append($('<div>').append(descriptionText));
                 $m.append('<hr>');
 
 
-                //descriptionText = '(for developers) View low-level data type schemas and specifications.  In general, don\'t operate on these schemas directly in your code.  Instead find '
-                //                   + 'an appropriate function to get and save data using a standard file format.';
-                //$m.append($('<h4>').append(self.makeLink(base+'datatypes', 'Data Type Catalog')))
-                //  .append($('<div>').append(descriptionText));
-                //$m.append('<hr>');
+                descriptionText = '(for developers) View low-level data type schemas and specifications.  In general, don\'t operate on these schemas directly in your code because they will '
+                                    + 'change.  Instead find an appropriate function to get and save data using a standard file format.';
+                $m.append($('<h4>').append(self.makeLink(base+'datatypes', 'Data Type Catalog')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
 
 
-                descriptionText = '(for developers) Browse and manage available KBase web services, which you should really only be using for interactive browser'
+                descriptionText = '(for developers) Browse and manage KBase web services, which you should only be using for interactive browser'
                                     + ' visualizations.  For SDK-built Apps, take a look at the Functions instead.';
                 $m.append($('<h4>').append(self.makeLink(base+'services', 'Web Service Status and Management')))
                   .append($('<div>').append(descriptionText));
                 $m.append('<hr>');
 
 
-                descriptionText = '(for developers) Register new Modules built with the KBase SDK to the system.  You should only use this page for your first registration.'
-                                    + '  After that, go to your Module page to access additional developer tools.';
-                $m.append($('<h4>').append(self.makeLink(base+'services', 'New Module Registration Page')))
+                descriptionText = '(for developers) Register new Modules built with the KBase SDK.  Use this page only for your first registration.'
+                                    + '  After that, go to your Module page to access developer tools.';
+                $m.append($('<h4>').append(self.makeLink(base+'register', 'New Module Registration Page')))
                   .append($('<div>').append(descriptionText));
                 $m.append('<hr>');
 
 
-                descriptionText = 'View the current status of the KBase Catalog, such as the deployed Catalog version and recent module registrations.';
+                descriptionText = 'View the current status of the KBase Catalog Service, such as recent module registrations.';
                 $m.append($('<h4>').append(self.makeLink(base+'status', 'Catalog Status')))
                   .append($('<div>').append(descriptionText));
                 $m.append('<hr>');
 
 
-                descriptionText = 'View summary usage statistics of the Narrative Apps currently available in KBase.';
-                $m.append($('<h4>').append(self.makeLink(base+'status', 'Catalog Stats')))
+                descriptionText = 'View summary statistics of Narrative Apps.';
+                $m.append($('<h4>').append(self.makeLink(base+'stats', 'Catalog Stats')))
                   .append($('<div>').append(descriptionText));
                 $m.append('<hr>');
 

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogIndex.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogIndex.js
@@ -1,0 +1,192 @@
+/*global
+ define
+ */
+/*jslint
+ browser: true,
+ white: true
+ */
+define([
+    'jquery',
+    'kb/service/client/narrativeMethodStore',
+    'kb/service/client/catalog',
+    './catalog_util',
+    'kb/widget/legacy/authenticatedWidget',
+    'bootstrap',
+],
+    function ($, NarrativeMethodStore, Catalog, CatalogUtil) {
+        $.KBWidget({
+            name: "KBaseCatalogIndex",
+            parent: "kbaseAuthenticatedWidget",  // todo: do we still need th
+            options: {
+            },
+
+            // clients to the catalog service and the NarrativeMethodStore
+            catalog: null,
+            nms: null,
+            util: null,
+
+            // main panel and elements
+            $mainPanel: null,
+            $loadingPanel: null,
+            $basicStatusDiv: null,
+            $pendingReleaseDiv: null,
+            $devListDiv: null,
+
+
+            build_list: null,
+            module_list: null,
+            catalog_version: null,
+            requested_releases: null,
+
+            isAdmin: null,
+
+            init: function (options) {
+                this._super(options);
+                
+                var self = this;
+
+                // new style we have a runtime object that gives us everything in the options
+                self.runtime = options.runtime;
+                self.setupClients();
+                self.isAdmin = false;
+
+                // initialize and add the main panel
+                var mainPanelElements = self.initMainPanel();
+                self.$mainPanel = mainPanelElements[0];
+                self.$mainLinks = mainPanelElements[1];
+                self.$adminLinks = mainPanelElements[2];
+                self.$elem.append(self.$mainPanel);
+
+                self.render();
+                self.renderAdminBlock();
+                return this;
+            },
+
+            render: function() {
+                var self = this;
+                var $m = self.$mainLinks;
+                var base = '#catalog/';
+
+
+                var descriptionText = 'Browse and search for Narrative Apps.  This is probably what you are looking for.';
+                $m.append($('<h4>').append(self.makeLink(base+'apps', 'App Catalog')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
+
+
+                descriptionText = 'View the list of registered KBase Modules.  Modules are groups of related Apps, code, functions, data and other components'
+                                    + ' registered from a single git repository by developers using the KBase SDK.';
+                $m.append($('<h4>').append(self.makeLink(base+'modules', 'Module Catalog')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
+
+
+                descriptionText = '(for developers) Browse and search functions that you can call from your code.  Think of it as your KBase API library that any developer can contribute to.'
+                $m.append($('<h4>').append(self.makeLink(base+'functions', 'Function Catalog')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
+
+
+                //descriptionText = '(for developers) View low-level data type schemas and specifications.  In general, don\'t operate on these schemas directly in your code.  Instead find '
+                //                   + 'an appropriate function to get and save data using a standard file format.';
+                //$m.append($('<h4>').append(self.makeLink(base+'datatypes', 'Data Type Catalog')))
+                //  .append($('<div>').append(descriptionText));
+                //$m.append('<hr>');
+
+
+                descriptionText = '(for developers) Browse and manage available KBase web services, which you should really only be using for interactive browser'
+                                    + ' visualizations.  For SDK-built Apps, take a look at the Functions instead.';
+                $m.append($('<h4>').append(self.makeLink(base+'services', 'Web Service Status and Management')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
+
+
+                descriptionText = '(for developers) Register new Modules built with the KBase SDK to the system.  You should only use this page for your first registration.'
+                                    + '  After that, go to your Module page to access additional developer tools.';
+                $m.append($('<h4>').append(self.makeLink(base+'services', 'New Module Registration Page')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
+
+
+                descriptionText = 'View the current status of the KBase Catalog, such as the deployed Catalog version and recent module registrations.';
+                $m.append($('<h4>').append(self.makeLink(base+'status', 'Catalog Status')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
+
+
+                descriptionText = 'View summary usage statistics of the Narrative Apps currently available in KBase.';
+                $m.append($('<h4>').append(self.makeLink(base+'status', 'Catalog Stats')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
+
+
+                descriptionText = '(for developers) Learn and get the tools for building your own KBase Modules, Apps, Services, and Functions.';
+                $m.append($('<h4>').append(self.makeLink('https://github.com/kbase/kb_sdk', 'KBase SDK')))
+                  .append($('<div>').append(descriptionText));
+                $m.append('<hr>');
+
+            },
+
+            makeLink: function(url, name) {
+                return $('<a href="'+url+'">').append(name);
+            },
+
+            renderAdminBlock: function() {
+                var self = this;
+                // make sure we are an admin
+                var loadingCalls = [];
+                loadingCalls.push(self.checkIsAdmin());
+
+                // when we have it all, then render the list
+                Promise.all(loadingCalls).then(function() {
+                    if(self.isAdmin) {
+
+                        var $a = self.$adminLinks;
+                        var base = '#catalog/';
+
+                        var descriptionText = 'You must be a Catalog administrator.  You should know what you\'re doing.';
+                        $a.append($('<h4>').append(self.makeLink(base+'admin', 'Catalog Administration')))
+                          .append($('<div>').append(descriptionText));
+                        $a.append('<hr>');
+
+                    }
+                });
+            },
+
+
+            setupClients: function() {
+                this.catalog = new Catalog(
+                    this.runtime.getConfig('services.catalog.url'),
+                    { token: this.runtime.service('session').getAuthToken() }
+                );
+            },
+
+            initMainPanel: function($appListPanel, $moduleListPanel) {
+                var $mainPanel = $('<div>').addClass('container');
+
+                var $adminLinks =  $('<div>');
+                $mainPanel.append($adminLinks);
+
+                var $mainLinks =  $('<div>');
+                $mainPanel.append($mainLinks);
+
+                return [$mainPanel, $mainLinks, $adminLinks];
+            },
+
+            checkIsAdmin: function() {
+                var self = this
+                var me = self.runtime.service('session').getUsername();
+                return self.catalog.is_admin(me)
+                    .then(function (result) {
+                        if(result) { self.isAdmin = true; }
+                    })
+                    .catch(function (err) {
+                        console.error('ERROR');
+                        console.error(err);
+                    });
+            }
+        });
+    });
+
+
+

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleBrowser.js
@@ -1,0 +1,211 @@
+/*global
+ define
+ */
+/*jslint
+ browser: true,
+ white: true
+ */
+define([
+    'jquery',
+    'bluebird',
+    'kb/service/client/catalog',
+    './catalog_util',
+    'datatables',
+    'kb/widget/legacy/authenticatedWidget',
+    'bootstrap'
+],
+    function ($, Promise, Catalog, CatalogUtil) {
+        $.KBWidget({
+            name: "KBaseCatalogModuleBrowser",
+            parent: "kbaseAuthenticatedWidget",  // todo: do we still need th
+            options: {
+            },
+
+            // clients to the catalog service and the NarrativeMethodStore
+            catalog: null,
+            util: null,
+
+            // main panel and elements
+            $mainPanel: null,
+            $loadingPanel: null,
+
+            moduleList:null,
+
+            init: function (options) {
+                this._super(options);
+                
+                var self = this;
+
+                // new style we have a runtime object that gives us everything in the options
+                self.runtime = options.runtime;
+                self.util = new CatalogUtil();
+                self.setupClients();
+
+                // initialize and add the main panel
+                self.$loadingPanel = self.util.initLoadingPanel();
+                self.$elem.append(self.$loadingPanel);
+                var mainPanelElements = self.initMainPanel();
+                self.$mainPanel = mainPanelElements[0];
+                self.$moduleListPanel = mainPanelElements[1];
+                self.$elem.append(self.$mainPanel);
+                self.showLoading();
+
+                var loadingCalls = [];
+                loadingCalls.push(self.populateModuleList());
+
+                // when we have it all, then render the list
+                Promise.all(loadingCalls).then(function() {
+                    self.render();
+                    self.hideLoading();
+                });
+
+                return this;
+            },
+
+            render: function() {
+                var self = this;
+
+
+                if(self.myModuleList.length > 0) {
+
+                    self.$moduleListPanel.append( $('<div>').append($('<h4>').append('My Modules')) );
+                    var $myModuleTable = self.renderTable(self.myModuleList);
+                    self.$moduleListPanel.append($myModuleTable);
+                    self.$moduleListPanel.append( $('<div>').css('height','30px') );
+                    self.$moduleListPanel.append( $('<div>').append($('<h4>').append('All Modules')) );
+                }
+
+                var $moduleTable = self.renderTable(self.moduleList);
+                self.$moduleListPanel.append($moduleTable);
+                self.$moduleListPanel.append( $('<div>').css('height','100px') );
+
+
+
+
+            },
+
+            renderTable: function(moduleData) {
+                var $table = $('<table>').addClass('table').css('width','100%');
+
+                var $container = $('<div>').addClass('container')
+                        .append($('<div>').addClass('row')
+                            .append($('<div>').addClass('col-md-12')
+                                .append($table)));
+
+                var limit = 10000; var sDom = 'tipf';
+                if(moduleData.length<limit) {
+                    sDom = 'ift';
+                }
+
+                var tblSettings = {
+                    "bFilter": true,
+                    "sPaginationType": "full_numbers",
+                    "iDisplayLength": limit,
+                    "sDom": sDom,
+                    "aaSorting": [[ 3, "dsc" ],[ 4, "dsc" ], [ 0, "asc" ]],
+                    "columns": [
+                        {sTitle: 'Module Name', data: "module_name_link"},
+                        {sTitle: "Owners", data: "owners_link"},
+                        {sTitle: "Language", data: "language"},
+                        {sTitle: "Released?", data: "is_released"},
+                        {sTitle: "Beta?", data: "has_beta"},
+                        {sTitle: "Service?", data: "is_service"},
+                        {sTitle: "Git URL", data: "git_url_link"}
+                    ],
+                    "data": moduleData
+                };
+                $table.DataTable(tblSettings);
+                $table.find('th').css('cursor','pointer');
+
+                return $container;
+            },
+
+
+            setupClients: function() {
+                this.catalog = new Catalog(
+                    this.runtime.getConfig('services.catalog.url'),
+                    { token: this.runtime.service('session').getAuthToken() }
+                );
+            },
+
+            initMainPanel: function($appListPanel, $moduleListPanel) {
+                var $mainPanel = $('<div>').addClass('container');
+
+                var $moduleListPanel =  $('<div>');
+                $mainPanel.append($moduleListPanel);
+
+                return [$mainPanel, $moduleListPanel];
+            },
+
+
+            populateModuleList: function() {
+                var self = this
+
+                var moduleSelection = {
+                    include_released:1,
+                    include_unreleased:1,
+                    include_disabled:0
+                };
+
+                return self.catalog.list_basic_module_info(moduleSelection)
+                    .then(function (modules) {
+                        self.moduleList = [];
+                        self.myModuleList = [];
+                        for(var k=0; k<modules.length; k++) {
+                            var moduleData = modules[k];
+
+                            moduleData['is_released'] = '';
+                            if(moduleData['release'] && moduleData['release']['git_commit_hash']) {
+                                moduleData['is_released'] = 'Yes (' + moduleData['release_version_list'].length + ')';
+                            }
+
+                            moduleData['has_beta'] = '';
+                            if(moduleData['beta'] && moduleData['beta']['git_commit_hash']) {
+                                moduleData['has_beta'] = 'Yes';
+                            }
+
+                            moduleData['is_service'] = '';
+                            if(moduleData['dynamic_service'] && moduleData['dynamic_service']==1) {
+                                moduleData['is_service'] = 'Yes';
+                            }
+
+                            moduleData['module_name_link'] = '<a href="#catalog/modules/'+ moduleData['module_name'] +'">' + moduleData['module_name'] + '</a>';
+                            moduleData['git_url_link'] = '<a href="'+ moduleData['git_url'] +'" target="_blank">' + moduleData['git_url'] + '</a>';
+                            moduleData['owners_link'] = '';
+                            var isMyModule = false;
+                            var me = self.runtime.service('session').getUsername();
+                            for(var o=0; o<moduleData['owners'].length; o++) {
+                                if(moduleData['owners'][o] === me) {
+                                    isMyModule = true;
+                                }
+                                if(o>=1) { moduleData['owners_link'] += ', '; }
+                                moduleData['owners_link'] += '<a href="#people/'+ moduleData['owners'][o] +'">' + moduleData['owners'][o] + '</a>';
+                            }
+                            self.moduleList.push(moduleData);
+                            if(isMyModule) {
+                                self.myModuleList.push(moduleData);
+                            }
+                        }
+                        console.log(self.moduleList)
+                    })
+                    .catch(function (err) {
+                        console.error('ERROR');
+                        console.error(err);
+                    });
+            },
+
+            showLoading: function() {
+                var self = this;
+                self.$loadingPanel.show();
+                self.$mainPanel.hide();
+            },
+            hideLoading: function() {
+                var self = this;
+                self.$loadingPanel.hide();
+                self.$mainPanel.show();
+            }
+        });
+    });
+
+
+

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleBrowser.js
@@ -128,8 +128,11 @@ define([
                 );
             },
 
-            initMainPanel: function($appListPanel, $moduleListPanel) {
+            initMainPanel: function() {
                 var $mainPanel = $('<div>').addClass('container');
+
+                $mainPanel.append($('<div>').addClass('kbcb-back-link')
+                        .append($('<a href="#catalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog Index')));
 
                 var $moduleListPanel =  $('<div>');
                 $mainPanel.append($moduleListPanel);

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleViewer.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleViewer.js
@@ -211,7 +211,7 @@ define([
                     $versionDiv.append(self.renderCollapsableVersionDiv(
                         'Development Version',
                         $('<div>')
-                            .append('<a href="#appcatalog/status/'+info.module_name+'">View recent registrations</a><br><br>')
+                            .append('<a href="#catalog/status/'+info.module_name+'">View recent registrations</a><br><br>')
                             .append(self.renderVersion('dev',info.dev))
                         ));
                 } else {
@@ -268,10 +268,10 @@ define([
                         for(var i=0; i<version.narrative_methods.length; i++) {
                             var id = version.narrative_methods[i];
                             if(tag) {
-                                $l.append('<li><a href="#appcatalog/app/'+this.moduleDetails.info.module_name+'/'+id+'/'+tag+
+                                $l.append('<li><a href="#catalog/apps/'+this.moduleDetails.info.module_name+'/'+id+'/'+tag+
                                     '">'+id+'</a></li>');
                             } else {
-                                $l.append('<li><a href="#appcatalog/app/'+this.moduleDetails.info.module_name+'/'+id+
+                                $l.append('<li><a href="#catalog/apps/'+this.moduleDetails.info.module_name+'/'+id+
                                     '">'+id+'</a></li>');
                             }
                             /*$l.append('<li><a href="#narrativestore/method/'+this.moduleDetails.info.module_name+'/'+id+
@@ -335,7 +335,7 @@ define([
                                 }));
 
 
-                $adminContent.append('<br><a href="#appcatalog/status/'+
+                $adminContent.append('<br><a href="#catalog/status/'+
                     self.moduleDetails.info.module_name+'">View recent registrations</a><br>')
                 
                 $adminContent.append('<br><b>Module state information:</b>');
@@ -481,7 +481,7 @@ define([
                 var $versionsPanel = $('<div>').css('margin','1em');
 
                 $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#appcatalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog/apps">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
                 
                 $mainPanel
                     .append($header)

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogRegistration.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogRegistration.js
@@ -187,7 +187,7 @@ define([
                 var $errorPanel = $('<div>').css('color','red').hide();
                 if(this.options.show_title) {
                     $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#appcatalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog/apps">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
                 }
                 $mainPanel
                     .append($inputPanel)

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogService.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogService.js
@@ -114,7 +114,7 @@ define([
                 var newEntry = {};
                 newEntry['actions'] = $('<button>').addClass('btn').append('start');
                 newEntry['module_name'] = entry['module_name'];
-                newEntry['module_name_link'] = '<a href="#appcatalog/module/'+entry['module_name']+'">'+entry['module_name']+'</a>';
+                newEntry['module_name_link'] = '<a href="#catalog/modules/'+entry['module_name']+'">'+entry['module_name']+'</a>';
                 newEntry['version'] =  entry['version'];
                 newEntry['git_commit_hash'] = entry['git_commit_hash'];
                 return newEntry;
@@ -172,7 +172,7 @@ define([
                     "data": data,
                     "fnCreatedRow": function( nRow, aData, iDataIndex ) {
 
-                        $('td:eq(0)', nRow).html('<a href="#appcatalog/module/'+aData['module_name']+'">'+aData['module_name']+'</a>');
+                        $('td:eq(0)', nRow).html('<a href="#catalog/modules/'+aData['module_name']+'">'+aData['module_name']+'</a>');
 
                         $('td:eq(6)', nRow).html('<div style="width:250px"><a href="'+aData['url']+'">'+aData['url']+'</a></div>');
 
@@ -353,7 +353,7 @@ define([
                 var $mainPanel = $('<div>').addClass('container');
 
                 $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#appcatalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog/apps">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
                 
                 $mainPanel.append($('<h3>').append('Catalog Service Status:'));
 

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogService.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogService.js
@@ -353,7 +353,7 @@ define([
                 var $mainPanel = $('<div>').addClass('container');
 
                 $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#catalog/apps">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog Index')));
                 
                 $mainPanel.append($('<h3>').append('Catalog Service Status:'));
 

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
@@ -215,7 +215,7 @@ define([
                 var $mainPanel = $('<div>').addClass('container');
 
                 $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#catalog/apps">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog Index')));
 
                 var $basicStatsDiv = $('<div>');
                 $mainPanel.append($basicStatsDiv);

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
@@ -215,7 +215,7 @@ define([
                 var $mainPanel = $('<div>').addClass('container');
 
                 $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#appcatalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog/apps">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
 
                 var $basicStatsDiv = $('<div>');
                 $mainPanel.append($basicStatsDiv);
@@ -284,8 +284,8 @@ define([
                             var meanQueueTime = s.total_queue_time/s.number_of_calls;
 
                             var stat = {
-                                id: '<a href="#appcatalog/app/'+s.full_app_id+'/dev">'+id+'</a>',
-                                module: '<a href="#appcatalog/module/'+s.module_name+'">'+s.module_name+'</a>',
+                                id: '<a href="#catalog/apps/'+s.full_app_id+'/dev">'+id+'</a>',
+                                module: '<a href="#catalog/modules/'+s.module_name+'">'+s.module_name+'</a>',
                                 nCalls: s.number_of_calls,
                                 nErrors: s.number_of_errors,
                                 success: successPercent.toPrecision(3),
@@ -345,8 +345,8 @@ define([
                                             module = s.app.split('/')[0];
                                             id = s.app.split('/')[1];
                                         }
-                                        id = '<a href="#appcatalog/app/'+module+'/'+id+'/dev">'+id+'</a>';
-                                        module = '<a href="#appcatalog/module/'+module+'">'+module+'</a>';
+                                        id = '<a href="#catalog/apps/'+module+'/'+id+'/dev">'+id+'</a>';
+                                        module = '<a href="#catalog/modules/'+module+'">'+module+'</a>';
                                     } else {
                                         if(s.func) {
                                             id = 'API Call: ' + s.func;
@@ -400,17 +400,17 @@ define([
                                 var mod = ''; //data[k]['app_module_name'];
                                 if(data[k]['app_module_name']) {
                                     mod = data[k]['app_module_name'];
-                                    data[k]['app_module_name']= '<a href="#appcatalog/module/'+mod+'">'
+                                    data[k]['app_module_name']= '<a href="#catalog/modules/'+mod+'">'
                                                                     +mod+'</a>';
                                 }
-                                data[k]['app_id']= '<a href="#appcatalog/app/'+mod+'/'+data[k]['app_id']+'">'+
+                                data[k]['app_id']= '<a href="#catalog/apps/'+mod+'/'+data[k]['app_id']+'">'+
                                                         data[k]['app_id']+'</a>';
                             } else {
                                 if(data[k]['func_name']) {
                                     data[k]['app_id'] = '(API):' + data[k]['func_name'];
                                     if(data[k]['func_module_name']) {
                                         mod = data[k]['func_module_name'];
-                                        data[k]['app_module_name']= '<a href="#appcatalog/module/'+mod+'">'
+                                        data[k]['app_module_name']= '<a href="#catalog/modules/'+mod+'">'
                                                                         +mod+'</a>';
                                     } else {
                                         data[k]['app_module_name'] = 'Unknown'

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStatus.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStatus.js
@@ -117,7 +117,7 @@ define([
                 var $mainPanel = $('<div>').addClass('container');
 
                 $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#appcatalog">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog/status">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
                 
                 $mainPanel.append($('<h3>').append('Catalog Status:'));
                 var $basicStatusDiv = $('<div>');
@@ -164,7 +164,7 @@ define([
                     for(var k=0; k<self.requested_releases.length; k++) {
                         var mod = self.requested_releases[k];
                         var $li = $('<li>');
-                        $li.append('<a href="#appcatalog/module/'+mod.module_name+'">'+mod.module_name+'</a>');
+                        $li.append('<a href="#catalog/modules/'+mod.module_name+'">'+mod.module_name+'</a>');
                         $li.append('- <a href="'+mod.git_url+'">'+mod.git_url+'</a><br>');
                         $li.append(mod.git_commit_hash + ' - '+mod.git_commit_message+'<br>');
                         $li.append('owners: [');
@@ -313,7 +313,7 @@ define([
                 var timestamp = self.util.getTimeStampStr(info.timestamp);
                 
                 if(info.module_name_lc) {
-                    $row.append('<strong><a href="#appcatalog/module/'+info.module_name_lc+'">'+info.module_name_lc+'</a></strong> - ');
+                    $row.append('<strong><a href="#catalog/modules/'+info.module_name_lc+'">'+info.module_name_lc+'</a></strong> - ');
                 } else {
                     $row.append('<strong>Module Name Not Detected</strong> - ');
                 }
@@ -321,7 +321,7 @@ define([
                 $row.append($('<span>').addClass('pull-right').css('color','#777')
                                     .append(timestamp)
                                     .append('<br>')
-                                    .append('<a href="#appcatalog/register/'+info.registration_id+'">'+info.registration_id+'</a>'));
+                                    .append('<a href="#catalog/register/'+info.registration_id+'">'+info.registration_id+'</a>'));
                 $row.append('<br>');
                 $row.append('Status: '+ info.registration);
                 if(info.error_message) {

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStatus.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStatus.js
@@ -117,7 +117,7 @@ define([
                 var $mainPanel = $('<div>').addClass('container');
 
                 $mainPanel.append($('<div>').addClass('kbcb-back-link')
-                        .append($('<a href="#catalog/status">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
+                        .append($('<a href="#catalog/apps">').append('<i class="fa fa-chevron-left"></i> back to the Catalog')));
                 
                 $mainPanel.append($('<h3>').append('Catalog Status:'));
                 var $basicStatusDiv = $('<div>');

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogTypeBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogTypeBrowser.js
@@ -1,0 +1,211 @@
+/*global
+ define
+ */
+/*jslint
+ browser: true,
+ white: true
+ */
+define([
+    'jquery',
+    'bluebird',
+    'kb/service/client/catalog',
+    './catalog_util',
+    'datatables',
+    'kb/widget/legacy/authenticatedWidget',
+    'bootstrap'
+],
+    function ($, Promise, Catalog, CatalogUtil) {
+        $.KBWidget({
+            name: "KBaseCatalogTypeBrowser",
+            parent: "kbaseAuthenticatedWidget",  // todo: do we still need th
+            options: {
+            },
+
+            // clients to the catalog service and the NarrativeMethodStore
+            catalog: null,
+            util: null,
+
+            // main panel and elements
+            $mainPanel: null,
+            $loadingPanel: null,
+
+            moduleList:null,
+
+            init: function (options) {
+                this._super(options);
+                
+                var self = this;
+
+                // new style we have a runtime object that gives us everything in the options
+                self.runtime = options.runtime;
+                self.util = new CatalogUtil();
+                self.setupClients();
+
+                // initialize and add the main panel
+                self.$loadingPanel = self.util.initLoadingPanel();
+                self.$elem.append(self.$loadingPanel);
+                var mainPanelElements = self.initMainPanel();
+                self.$mainPanel = mainPanelElements[0];
+                self.$moduleListPanel = mainPanelElements[1];
+                self.$elem.append(self.$mainPanel);
+                self.showLoading();
+
+                var loadingCalls = [];
+                loadingCalls.push(self.populateModuleList());
+
+                // when we have it all, then render the list
+                Promise.all(loadingCalls).then(function() {
+                    self.render();
+                    self.hideLoading();
+                });
+
+                return this;
+            },
+
+            render: function() {
+                var self = this;
+
+
+                if(self.myModuleList.length > 0) {
+
+                    self.$moduleListPanel.append( $('<div>').append($('<h4>').append('My Modules')) );
+                    var $myModuleTable = self.renderTable(self.myModuleList);
+                    self.$moduleListPanel.append($myModuleTable);
+                    self.$moduleListPanel.append( $('<div>').css('height','30px') );
+                    self.$moduleListPanel.append( $('<div>').append($('<h4>').append('All Modules')) );
+                }
+
+                var $moduleTable = self.renderTable(self.moduleList);
+                self.$moduleListPanel.append($moduleTable);
+                self.$moduleListPanel.append( $('<div>').css('height','100px') );
+
+
+
+
+            },
+
+            renderTable: function(moduleData) {
+                var $table = $('<table>').addClass('table').css('width','100%');
+
+                var $container = $('<div>').addClass('container')
+                        .append($('<div>').addClass('row')
+                            .append($('<div>').addClass('col-md-12')
+                                .append($table)));
+
+                var limit = 10000; var sDom = 'tipf';
+                if(moduleData.length<limit) {
+                    sDom = 'ift';
+                }
+
+                var tblSettings = {
+                    "bFilter": true,
+                    "sPaginationType": "full_numbers",
+                    "iDisplayLength": limit,
+                    "sDom": sDom,
+                    "aaSorting": [[ 3, "dsc" ],[ 4, "dsc" ], [ 0, "asc" ]],
+                    "columns": [
+                        {sTitle: 'Module Name', data: "module_name_link"},
+                        {sTitle: "Owners", data: "owners_link"},
+                        {sTitle: "Language", data: "language"},
+                        {sTitle: "Released?", data: "is_released"},
+                        {sTitle: "Beta?", data: "has_beta"},
+                        {sTitle: "Service?", data: "is_service"},
+                        {sTitle: "Git URL", data: "git_url_link"}
+                    ],
+                    "data": moduleData
+                };
+                $table.DataTable(tblSettings);
+                $table.find('th').css('cursor','pointer');
+
+                return $container;
+            },
+
+
+            setupClients: function() {
+                this.catalog = new Catalog(
+                    this.runtime.getConfig('services.catalog.url'),
+                    { token: this.runtime.service('session').getAuthToken() }
+                );
+            },
+
+            initMainPanel: function($appListPanel, $moduleListPanel) {
+                var $mainPanel = $('<div>').addClass('container');
+
+                var $moduleListPanel =  $('<div>');
+                $mainPanel.append($moduleListPanel);
+
+                return [$mainPanel, $moduleListPanel];
+            },
+
+
+            populateModuleList: function() {
+                var self = this
+
+                var moduleSelection = {
+                    include_released:1,
+                    include_unreleased:1,
+                    include_disabled:0
+                };
+
+                return self.catalog.list_basic_module_info(moduleSelection)
+                    .then(function (modules) {
+                        self.moduleList = [];
+                        self.myModuleList = [];
+                        for(var k=0; k<modules.length; k++) {
+                            var moduleData = modules[k];
+
+                            moduleData['is_released'] = '';
+                            if(moduleData['release'] && moduleData['release']['git_commit_hash']) {
+                                moduleData['is_released'] = 'Yes (' + moduleData['release_version_list'].length + ')';
+                            }
+
+                            moduleData['has_beta'] = '';
+                            if(moduleData['beta'] && moduleData['beta']['git_commit_hash']) {
+                                moduleData['has_beta'] = 'Yes';
+                            }
+
+                            moduleData['is_service'] = '';
+                            if(moduleData['dynamic_service'] && moduleData['dynamic_service']==1) {
+                                moduleData['is_service'] = 'Yes';
+                            }
+
+                            moduleData['module_name_link'] = '<a href="#catalog/modules/'+ moduleData['module_name'] +'">' + moduleData['module_name'] + '</a>';
+                            moduleData['git_url_link'] = '<a href="'+ moduleData['git_url'] +'" target="_blank">' + moduleData['git_url'] + '</a>';
+                            moduleData['owners_link'] = '';
+                            var isMyModule = false;
+                            var me = self.runtime.service('session').getUsername();
+                            for(var o=0; o<moduleData['owners'].length; o++) {
+                                if(moduleData['owners'][o] === me) {
+                                    isMyModule = true;
+                                }
+                                if(o>=1) { moduleData['owners_link'] += ', '; }
+                                moduleData['owners_link'] += '<a href="#people/'+ moduleData['owners'][o] +'">' + moduleData['owners'][o] + '</a>';
+                            }
+                            self.moduleList.push(moduleData);
+                            if(isMyModule) {
+                                self.myModuleList.push(moduleData);
+                            }
+                        }
+                        console.log(self.moduleList)
+                    })
+                    .catch(function (err) {
+                        console.error('ERROR');
+                        console.error(err);
+                    });
+            },
+
+            showLoading: function() {
+                var self = this;
+                self.$loadingPanel.show();
+                self.$mainPanel.hide();
+            },
+            hideLoading: function() {
+                var self = this;
+                self.$loadingPanel.hide();
+                self.$mainPanel.show();
+            }
+        });
+    });
+
+
+

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseViewSDKRegistrationLog.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseViewSDKRegistrationLog.js
@@ -66,7 +66,7 @@ define(['jquery',
             container.append($table);
             var width = "15%"
 
-            $table.append('<tr><td width="'+width+'">Registration ID</td><td><a href="#appcatalog/register/'+self.registration_id+'">'
+            $table.append('<tr><td width="'+width+'">Registration ID</td><td><a href="#catalog/register/'+self.registration_id+'">'
                 +self.registration_id+'</a></td></tr>');
 
             self.$registration_state_td = $('<td></td>')
@@ -173,7 +173,7 @@ define(['jquery',
                 if(self.options.show_module_links) {
                     self.$registration_state_td.append('&nbsp;&nbsp;&nbsp;');
                     self.$registration_state_td.append(
-                            'Successfully registered <a href="#appcatalog/module/'+build_info.module_name_lc+'">'+build_info.module_name_lc+'</a> '
+                            'Successfully registered <a href="#catalog/modules/'+build_info.module_name_lc+'">'+build_info.module_name_lc+'</a> '
                         );
                     self.$registration_state_td.append(
                             'from <a href="'+build_info.git_url+'" target="_blank">'+build_info.git_url+'</a>.'


### PR DESCRIPTION
In addition to a lot of minor updates, this PR slightly reorganizes the routes so that instead of of #appcatalog/..., there is #catalog/apps, #catalog/functions, #cataloag/modules, etc.  The old routes still work though so we don't have to update any links right away.

With all these new pages, I also added a catalog index page at #catalog and #catalog/index routes to make navigation a little easier.

Finally, since I was in the code already and had started these pages a while ago, I finally put up a simple module listing page (#catalog/modules) and a type listing page (#catalog/datatypes) which is helpful mainly just for us for now.