### PR TITLE
App catalog tweaks

### DIFF
--- a/src/client/modules/plugins/catalog/modules/app_card.js
+++ b/src/client/modules/plugins/catalog/modules/app_card.js
@@ -15,27 +15,42 @@ define([
     //      module_name:
     //      ...
     //     
-    function AppCard(type, info, tag, nms_base_url, favoritesCallback, favoritesCallbackParams, isLoggedIn) {
+
+    //params = {
+    //    legacy : true | false // indicates if this is a legacy App or SDK App
+    //    app:  { .. }  // app info returned (for now) from NMS
+    //    module: { .. }  // module info returned for SDK methods
+    //    favoritesCallback: function () // function called when favorites button is clicked
+    //    favoritesCallbackParams: {} // parameters passed on to the callback function
+    //    isLoggedIn: true | false
+    //    showReleaseTagLabels: true | false
+    //    linkTag: dev | beta | release | commit_hash
+    //}
+
+    function AppCard(params) {
 
         this.$divs = [];
-        this.info = info;
-        this.type = type;
-        this.tag = tag;
-        this.nms_base_url = nms_base_url;
+        this.info = params.app;
+        this.module = params.module;
+        this.legacy = params.legacy;
+        this.nms_base_url = params.nms_base_url;
+        this.isLoggedIn = params.isLoggedIn;
+        this.showReleaseTagLabels = false;
+        this.linkTag = params.linkTag;
+        if(params.showReleaseTagLabels && params.showReleaseTagLabels==true) {
+            this.showReleaseTagLabels = true;
+        }
+
         this.cardsAdded = 0;
 
-        this.isLoggedIn = isLoggedIn;
-
-        this.favoritesCallback = favoritesCallback;
-        this.favoritesCallbackParams = favoritesCallbackParams;
+        this.favoritesCallback = params.favoritesCallback;
+        this.favoritesCallbackParams = params.favoritesCallbackParams;
 
         // only an SDK module if it has a module name
         this.isSdk = false;
-        if(this.info.module_name) {
+        if(this.module) {
             this.isSdk = true;
         }
-
-
 
         this.show = function() {
             for(var k=0; k<this.$divs.length; k++) {
@@ -155,9 +170,12 @@ define([
         this._renderAppCard = function() {
 
             var info = this.info;
-            var type = this.type;
-            var tag = this.tag;
+            var module = this.module;
+            var legacy = this.legacy;
+            var isSdk = this.isSdk;
             var nms_base_url = this.nms_base_url;
+            var linkTag = this.linkTag;
+            
 
             // Main Container
             var $appDiv = $('<div>').addClass('kbcb-app-card kbcb-hover container');
@@ -166,9 +184,9 @@ define([
             var $topDiv = $('<div>').addClass('row kbcb-app-card-header');
             var $logoSpan = $('<div>').addClass('col-xs-3 kbcb-app-card-logo');
 
-            if(type === 'method') {
+            if(!legacy) {
                 $logoSpan.append('<div class="fa-stack fa-3x"><i class="fa fa-square fa-stack-2x method-icon"></i><i class="fa fa-inverse fa-stack-1x fa-cube"></i></div>')
-            } else if (type === 'app') {
+            } else {
                 $logoSpan.append('<span class="fa-stack fa-3x"><span class="fa fa-square fa-stack-2x app-icon"></span><span class="fa fa-inverse fa-stack-1x fa-cubes" style=""></span></span>');
             }
 
@@ -184,17 +202,19 @@ define([
             var $titleSpan = $('<div>').addClass('col-xs-9 kbcb-app-card-title-panel');
                 
             $titleSpan.append($('<div>').addClass('kbcb-app-card-title').append(info.name));
-            if(info['module_name']) {
+            if(isSdk) {
                 $titleSpan.append($('<div>').addClass('kbcb-app-card-module').append(
-                                        $('<a href="#catalog/modules/'+info.module_name+'">')
-                                            .append(info.module_name)
+                                        $('<a href="#catalog/modules/'+module.module_name+'">')
+                                            .append(module.module_name)
                                             .on('click',function(event) {
                                                 // have to stop propagation so we don't go to the app page first
                                                 event.stopPropagation();
-                                            })));
+                                            }))
+                                        //.append(' v'+module.version)
+                                );
             }
 
-            if(type==='method') {
+            if(!legacy) {
                 if(info.authors.length>0) {
                     var $authorDiv = $('<div>').addClass('kbcb-app-card-authors').append('by ');
                     for(var k=0; k<info.authors.length; k++) {
@@ -230,13 +250,14 @@ define([
             // FOOTER - stars, number of runs, and info mouseover area
             var $footer = $('<div>').addClass('clearfix kbcb-app-card-footer');
 
-            if(type==='method') {
+            if(!legacy) {
                 var $starDiv = $('<div>').addClass('col-xs-3').css('text-align','left');
                 var $star = $('<span>').addClass('kbcb-star').append('<i class="fa fa-star"></i>');
                 var self = this;
                 if(self.isLoggedIn) {
                     $star.addClass('kbcb-star-nonfavorite');
                     $star.on('click', function(event) {
+                        console.log('here')
                         event.stopPropagation();
                         if(!self.deactivatedStar && self.favoritesCallback) {
                             self.favoritesCallback(self.info, self.favoritesCallbackParams)
@@ -254,7 +275,7 @@ define([
                 $footer.append($('<div>').addClass('col-xs-3'))
             }
 
-            if(this.isSdk) {
+            if(isSdk) {
                 var nRuns = Math.floor(Math.random()*10000);
                 var $nRuns = $('<div>').addClass('col-xs-3').css('text-align','left');
                 $nRuns.append($('<span>').addClass('kbcb-runs'));
@@ -270,8 +291,29 @@ define([
                 $footer.append($('<div>').addClass('col-xs-3'))
             }
 
-            // buffer
-            $footer.append($('<div>').addClass('col-xs-4').css('text-align','left'));
+            // version tags
+            if(this.showReleaseTagLabels) {
+                if(isSdk) {
+                    var $ver_tags = $('<div>').addClass('col-xs-4').css('text-align','left');
+                    if(module.release && module.release.git_commit_hash && module.release.git_commit_hash===info.git_commit_hash) {
+                        $ver_tags.append('<span class="label label-primary">R</span>');
+                    }
+                    if(module.beta && module.beta.git_commit_hash && module.beta.git_commit_hash===info.git_commit_hash) {
+                        $ver_tags.append('<span class="label label-info">B</span>');
+                    }
+                    if(module.dev && module.dev.git_commit_hash && module.dev.git_commit_hash===info.git_commit_hash) {
+                        $ver_tags.append('<span class="label label-default">D</span>');
+                    }
+                    $footer.append($ver_tags);
+
+                } else {
+                    $footer.append($('<div>').addClass('col-xs-4').css('text-align','left')
+                        .append('<span class="label label-primary">R</span>'));
+                }
+            } else {
+                $footer.append($('<div>').addClass('col-xs-4').css('text-align','left'));
+
+            }
 
             var $moreInfoDiv = $('<div>').addClass('col-xs-1').addClass('kbcb-info').css('text-align','right');
             $moreInfoDiv
@@ -289,12 +331,12 @@ define([
 
 
             $appDiv.on('click', function() {
-                if(type === 'method') {
+                if(!legacy) {
                     if(info.module_name) {
                         // module name right now is encoded in the ID
                         //window.location.href = '#appcatalog/app/'.info.module_name+'/'+app.info.id;
-                        if(tag) {
-                            window.location.href = '#catalog/apps/'+info.id + '/'+tag;
+                        if(linkTag) {
+                            window.location.href = '#catalog/apps/'+info.id + '/'+linkTag;
                         } else {
                             window.location.href = '#catalog/apps/'+info.id;
                         }

--- a/src/client/modules/plugins/catalog/modules/app_card.js
+++ b/src/client/modules/plugins/catalog/modules/app_card.js
@@ -175,7 +175,7 @@ define([
             var isSdk = this.isSdk;
             var nms_base_url = this.nms_base_url;
             var linkTag = this.linkTag;
-            
+
 
             // Main Container
             var $appDiv = $('<div>').addClass('kbcb-app-card kbcb-hover container');
@@ -296,13 +296,19 @@ define([
                 if(isSdk) {
                     var $ver_tags = $('<div>').addClass('col-xs-4').css('text-align','left');
                     if(module.release && module.release.git_commit_hash && module.release.git_commit_hash===info.git_commit_hash) {
-                        $ver_tags.append('<span class="label label-primary">R</span>');
+                        $ver_tags.append($('<span>').addClass('label label-primary').append('R')
+                                                    .tooltip({title:'Tagged as the latest released version.', placement:'bottom', container:'body',
+                                                                delay:{show: 400, hide: 40}}));
                     }
                     if(module.beta && module.beta.git_commit_hash && module.beta.git_commit_hash===info.git_commit_hash) {
-                        $ver_tags.append('<span class="label label-info">B</span>');
+                        $ver_tags.append($('<span>').addClass('label label-info').append('B')
+                                                    .tooltip({title:'Tagged as the current beta version.', placement:'bottom', container:'body',
+                                                                delay:{show: 400, hide: 40}}));
                     }
                     if(module.dev && module.dev.git_commit_hash && module.dev.git_commit_hash===info.git_commit_hash) {
-                        $ver_tags.append('<span class="label label-default">D</span>');
+                        $ver_tags.append($('<span>').addClass('label label-default').append('D')
+                                                    .tooltip({title:'Tagged as the current development version.', placement:'bottom', container:'body',
+                                                                delay:{show: 400, hide: 40}}));
                     }
                     $footer.append($ver_tags);
 

--- a/src/client/modules/plugins/catalog/modules/function_card.js
+++ b/src/client/modules/plugins/catalog/modules/function_card.js
@@ -149,6 +149,7 @@ define([
         this._renderFunctionCard = function() {
 
             var info = this.info;
+            console.log(info)
 
             // Main Container
             var $appDiv = $('<div>').addClass('kbcb-app-card kbcb-hover container');
@@ -163,12 +164,6 @@ define([
             $titleSpan.append($('<div>').addClass('kbcb-function-prototype-title').css({'margin':'4px'})
                 .append('funcdef <span style="font-weight:bold">'+info.function_id+'</span>(...)'));
 
-            var release_tag = '';
-            if(info.release_tag) {
-                if(info.release_tag == 'beta' || info.release_tag == 'dev') {
-                    release_tag = ' '+info.release_tag;
-                }
-            }
             $titleSpan.append($('<div>').addClass('kbcb-app-card-module').css({'padding-top':'4px'}).append(
                                     $('<a href="#catalog/modules/'+info.module_name+'">')
                                         .append(info.module_name)
@@ -176,7 +171,7 @@ define([
                                             // have to stop propagation so we don't go to the app page first
                                             event.stopPropagation();
                                         }))
-                                    .append(' v'+info.version + release_tag)
+                                    .append(' v'+info.version)
                             );
 
             
@@ -234,8 +229,33 @@ define([
             }*/
             $footer.append($('<div>').addClass('col-xs-3').css('text-align','left'));
 
-            // buffer spacing before the info icon
-            $footer.append($('<div>').addClass('col-xs-4').css('text-align','left'));
+            // add release tag information
+            var $releaseTagsDiv = $('<div>').addClass('col-xs-4').css('text-align','left');
+            $footer.append($releaseTagsDiv);
+
+            for(var r=0; r<info.release_tag.length; r++) {
+                var rts = info.release_tag;
+                for(var r=0; r<rts.length; r++) {
+                    if(rts[r]==='release') {
+                        $releaseTagsDiv.append($('<span>').addClass('label label-primary').css({'padding':'.3em .6em .3em'})
+                                                        .append('R')
+                                                        .tooltip({title:'Tagged as the latest released version.', placement:'bottom', container:'body',
+                                                                    delay:{show: 400, hide: 40}}));
+                    }
+                    if(rts[r]==='beta') {
+                        $releaseTagsDiv.append($('<span>').addClass('label label-info').css({'padding':'.3em .6em .3em'})
+                                                        .append('B')
+                                                        .tooltip({title:'Tagged as the current beta version.', placement:'bottom', container:'body',
+                                                                    delay:{show: 400, hide: 40}}));
+                    }
+                    if(rts[r]==='dev') {
+                        $releaseTagsDiv.append($('<span>').addClass('label label-default').css({'padding':'.3em .6em .3em'})
+                                                        .append('D')
+                                                        .tooltip({title:'Tagged as the current development version.', placement:'bottom', container:'body',
+                                                                    delay:{show: 400, hide: 40}}));
+                    }
+                }
+            }
 
             var $moreInfoDiv = $('<div>').addClass('col-xs-1').addClass('kbcb-info').css('text-align','right');
             $moreInfoDiv

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAppViewer.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogAppViewer.js
@@ -73,7 +73,6 @@ define([
                 self.tag = options.tag;
                 self.isGithub = false;
 
-
                 // initialize and add the main panel
                 //self.$elem.addClass('container');
                 self.$errorPanel = $('<div>');
@@ -113,9 +112,18 @@ define([
                             self.updateFavoritesCounts();
                             self.updateRunStats();
                             return null;
-                        }).catch(function() {
+                        }).catch(function (err) {
+                            console.error('ERROR');
+                            console.error(err);
+                            self.showError(err);
                             self.hideLoading();
                         });
+                    })
+                    .catch(function (err) {
+                        console.error('ERROR');
+                        console.error(err);
+                        self.showError(err);
+                        self.hideLoading();
                     });
                 return this;
             },
@@ -152,16 +160,8 @@ define([
 
                 return self.nms.get_method_full_info(params)
                     .then(function(info_list) {
-                        console.log('Method full info:')
-                        console.log(info_list);
+                        console.log('(NMS) App full info:',info_list);
                         self.appFullInfo = info_list[0];
-                        return null;
-                    })
-                    .catch(function (err) {
-                        console.error('ERROR');
-                        console.error(err);
-                        self.showError(err);
-                        return err;
                     });
             },
             getAppSpec: function() {
@@ -180,14 +180,8 @@ define([
 
                 return self.nms.get_method_spec(params)
                     .then(function(specs) {
-                        console.log('Specs:')
-                        console.log(specs);
+                        console.log('(NMS) App Specs:',specs);
                         self.appSpec = specs[0];
-                    })
-                    .catch(function (err) {
-                        console.error('ERROR');
-                        console.error(err);
-                        self.showError(err);
                     });
             },
 
@@ -201,22 +195,17 @@ define([
                 var moduleSelection = {
                     module_name: self.module_name
                 };
+                if(self.tag) {
+                    moduleSelection.version = self.tag;
+                }
 
-                return self.catalog.get_module_info(moduleSelection)
+                return self.catalog.get_module_version(moduleSelection)
                     .then(function (info) {
-                        /*typedef structure {
-                            string module_name;
-                            string git_url;
+                        console.log('(Catalog) Module Version:',info);
 
-                            string description;
-                            string language;
-
-                            list <string> owners;
-
-                            ModuleVersionInfo release;
-                            ModuleVersionInfo beta;
-                            ModuleVersionInfo dev;
-                        } ModuleInfo;*/
+                        if(!self.tag) {
+                            self.tag = info['git_commit_hash']; 
+                        }
 
                         // make sure the ID and module name case is correct
                         var idTokens = self.id.split('/');
@@ -241,6 +230,7 @@ define([
                         console.error('ERROR');
                         console.error(err);
                         self.showError(err);
+                        self.hideLoading();
                     });
             },
 
@@ -326,18 +316,39 @@ define([
                                     .append($('<td>').append(commit)))
                                 );
                         });
+                } else {
+                    // sdk App, so check if we can get some info here
+                    if(self.moduleDetails.info) {
+                        var p = '5px';
+                        if(self.isGithub) {
+                            var url = self.moduleDetails.info.git_url + "/tree/" + self.moduleDetails.info.git_commit_hash;
+                            url += "/ui/narrative/methods/" + self.options.id;
+                            self.$infoPanel.append('<br>');
+                            self.$infoPanel.append(
+                                $('<table>').css({border: '1px solid #bbb', margin: '10px'})
+                                    .append($('<tr>')
+                                        .append($('<th style = "vertical-align : top;" >').css('padding',p).append('App Specification: '))
+                                        .append($('<td>').css('padding',p).append('<a href="' + url + '" target="_blank">' + url + "</a>")))
+                                    .append($('<tr>')
+                                        .append($('<th style = "vertical-align : top;" >').css('padding',p).append('Module Commit:  '))
+                                        .append($('<td>').css('padding',p).append(self.moduleDetails.info.git_commit_hash)))
+                                    );
+                        } else {
+                            self.$infoPanel.append('<br>');
+                            self.$infoPanel.append(
+                                $('<table>').css({border: '1px solid #bbb', margin: '10px'})
+                                    .append($('<tr>')
+                                        .append($('<th style = "vertical-align : top;" >').css('padding',p).append('Git URL: '))
+                                        .append($('<td>').css('padding',p).append('<a href="' + self.moduleDetails.info.git_url + '" target="_blank">' + self.moduleDetails.info.git_url + "</a>")))
+                                    .append($('<tr>')
+                                        .append($('<th style = "vertical-align : top;" >').css('padding',p).append('Module Commit:  '))
+                                        .append($('<td>').css('padding',p).append(self.moduleDetails.info.git_commit_hash)))
+                                    );
+                        }
+                    }
+
                 }
                 return Promise.try(function() {});
-
-                /*if(self.isGithub) {
-                    var url = self.moduleDetails.info.git_url + ;
-                    self.$infoPanel.append(
-                        $('<table>').addClass('table').css({border: '1px solid #bbb', margin: '10px', padding: '10px'})
-                            .append($('<tr>')
-                                .append($('<th style = "vertical-align : top; padding-right : 5px">').append('Yaml/Spec Location '))
-                                .append($('<td>').append('<a href="' + url + '" target="_blank">' + url + "</a>"))));
-
-                }*/
 
             },
 
@@ -699,16 +710,14 @@ define([
             updateRunStats: function() {
                 var self = this
 
-                var options = { full_app_ids : [self.appFullInfo.id] }; // eventuall add p
-                console.log(options);
+                var options = { full_app_ids : [self.appFullInfo.id] };
 
                 return self.catalog.get_exec_aggr_stats(options)
                     .then(function (stats) {
                         // should only get one for now- when we switch to 'per_week' stats, then we will get one record per week
                         if(stats.length>0) {
                             var s = stats[0];
-                            console.log('Stats:')
-                            console.log(s);
+                            console.log('(Catalog) Stats:',s);
                             /*
                                 full_app_id - optional fully qualified method-spec id including module_name prefix followed
                                     by slash in case of dynamically registered repo (it could be absent or null in case
@@ -814,25 +823,16 @@ define([
 
                 var $titleSpan = $('<div>').addClass('kbcb-app-page-title-panel');
                 
-
-                var versiontag = '';
-                if(self.tag) {
-                    if(self.tag=='dev') {
-                        versiontag = ' (under development)'
-                    } else if(self.tag=='beta') {
-                        versiontag = ' beta'
-                    }
-                }
-
                 $titleSpan.append($('<div>').addClass('kbcb-app-page-title').append(m.name).append(
                     $('<span>').css({'font-size':'0.5em','margin-left':'0.5em'})
-                        .append(versiontag)));
+                        ));
                 
 
                 if(self.moduleDetails.info) {
                     $titleSpan.append($('<div>').addClass('kbcb-app-page-module').append(
                                             $('<a href="#catalog/modules/'+self.moduleDetails.info.module_name+'">')
-                                                .append(self.moduleDetails.info.module_name)));
+                                                .append(self.moduleDetails.info.module_name))
+                                            .append(' v.'+self.moduleDetails.info.version));
                 }
 
                 if(m.authors.length>0) {
@@ -882,7 +882,41 @@ define([
                 $starDiv.append($star).append($starCount);
 
 
-                var $nRuns = $('<div>').addClass('kbcb-runs').addClass('col-xs-10');
+                var $releaseTagsDiv = $('<div>').addClass('col-xs-2');
+
+                if(self.moduleDetails.info) {
+                    var rts = self.moduleDetails.info.release_tags;
+                    for(var r=0; r<rts.length; r++) {
+                        if(rts[r]==='release') {
+                            $releaseTagsDiv.append($('<span>').addClass('label label-primary').css({'padding':'.3em .6em .3em'})
+                                                        .append('R')
+                                                        .tooltip({title:'Tagged as the latest released version.', placement:'bottom', container:'body',
+                                                                    delay:{show: 400, hide: 40}}));
+                        }
+                        if(rts[r]==='beta') {
+                            $releaseTagsDiv.append($('<span>').addClass('label label-info').css({'padding':'.3em .6em .3em'})
+                                                        .append('B')
+                                                        .tooltip({title:'Tagged as the current beta version.', placement:'bottom', container:'body',
+                                                                    delay:{show: 400, hide: 40}}));
+                        }
+                        if(rts[r]==='dev') {
+                            $releaseTagsDiv.append($('<span>').addClass('label label-default').css({'padding':'.3em .6em .3em'})
+                                                        .append('D')
+                                                        .tooltip({title:'Tagged as the current development version.', placement:'bottom', container:'body',
+                                                                    delay:{show: 400, hide: 40}}));
+                        }
+                    }
+                } else {
+                    // this is a legacy method, so it must be released
+                    $releaseTagsDiv.append($('<span>').addClass('label label-primary').css({'padding':'.3em .6em .3em'})
+                                                        .append('R')
+                                                        .tooltip({title:'Tagged as the latest released version.', placement:'bottom', container:'body',
+                                                                    delay:{show: 400, hide: 40}}));
+                }
+
+
+
+                var $nRuns = $('<div>').addClass('kbcb-runs').addClass('col-xs-8');
 
 
                 if(self.isLegacyMethod || self.isLegacyApp) {
@@ -893,6 +927,7 @@ define([
                     $('<div>').addClass('kbcb-app-page-stats-bar container').append(
                         $('<div>').addClass('row')
                             .append($starDiv)
+                            .append($releaseTagsDiv)
                             .append($nRuns)));
 
 
@@ -978,6 +1013,11 @@ define([
 
 
                 if (m.description) {
+
+                    // replace instances of emailing help@kbase.us to contact us
+                    var re = /For questions.{0,50}<a href="mailto:help@kbase.us".{1,50}help@kbase.us.{0,5}<\/a>/g; 
+                    var d_text = m.description.replace(re, 'Questions? Suggestions? Bug reports? Please <a href="https://kbase.us/contact-us/">contact us</a> and include the app name.');
+
                     self.$descriptionPanel
                         .append(
                             $.jqElem('div')
@@ -989,7 +1029,7 @@ define([
                                 .append(
                                     $.jqElem('div')
                                     .append($.jqElem('hr'))
-                                    .append(m.description)
+                                    .append(d_text)
                                     )
                                 )
                             )

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogBrowser.js
@@ -73,12 +73,27 @@ define([
                     util : 'Utilities'
                 };
 
-
                 // new style we have a runtime object that gives us everything in the options
                 self.runtime = options.runtime;
+                self.isLoggedIn = self.runtime.service('session').isLoggedIn();
                 //console.log(this.runtime.service('session').getUsername());
                 self.util = new CatalogUtil();
                 self.setupClients();
+
+                // process the 'tag' argument, which can only be dev | beta | release
+                self.showReleaseTagLabels = true;
+                if(self.options.tag) {
+                    self.options.tag = self.options.tag.toLowerCase();
+                    if(self.options.tag!=='dev' && self.options.tag!=='beta' && self.options.tag!=='release') {
+                        console.warn('tag '+self.options.tag+ ' is not valid! Use: dev/beta/release.  defaulting to release.');
+                        self.options.tag = 'release';
+                    }
+                } else {
+                    self.options.tag = 'release';
+                }
+                if(self.options.tag==='release') {
+                    self.showReleaseTagLabels = false;
+                }
 
                 // initialize and add the control bar
                 var $container = $('<div>').addClass('container');
@@ -101,15 +116,18 @@ define([
                 // get the list of apps and modules
                 var loadingCalls = [];
                 self.appList = []; self.moduleList = [];
-                loadingCalls.push(self.populateAppListWithMethods());
-                loadingCalls.push(self.populateAppListWithApps());
-                loadingCalls.push(self.populateModuleList());
+                loadingCalls.push(self.populateAppList(self.options.tag));
+                loadingCalls.push(self.populateModuleList(self.options.tag));
+                // only show legacy apps if we are showing everything
+                self.legacyApps=[];
+                if(self.options.tag==='release') {
+                    loadingCalls.push(self.populateAppListWithLegacyApps());
+                }
 
                 // when we have it all, then render the list
                 Promise.all(loadingCalls).then(function() {
 
                     self.processData();
-
 
                     self.updateFavoritesCounts()
                         .then(function() {
@@ -180,7 +198,7 @@ define([
 
                 // ORGANIZE BY
                 var $obMyFavs = $('<a>');
-                if(self.runtime.service('session').isLoggedIn()) {
+                if(self.isLoggedIn) {
                     $obMyFavs.append('My Favorites')
                                     .on('click', function() {self.renderAppList('my_favorites')});
                 }
@@ -235,9 +253,9 @@ define([
 
 
                 // ORGANIZE BY
-                var $verR = $('<a href="#catalog/apps/release">').append('Released Modules');
-                var $verB = $('<a href="#catalog/apps/beta">').append('Beta Modules');
-                var $verD = $('<a href="#catalog/apps/dev">').append('Modules in Development');
+                var $verR = $('<a href="#catalog/apps/release">').append('Released Apps');
+                var $verB = $('<a href="#catalog/apps/beta">').append('Beta Apps');
+                var $verD = $('<a href="#catalog/apps/dev">').append('Apps in Development');
 
                 var $version = $('<li>').addClass('dropdown')
                                     .append('<a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Version<span class="caret"></span></a>')
@@ -400,6 +418,7 @@ define([
             //    catalog: catalog_client
             //    browserWidget: this widget, so we can toggle any update
             toggleFavorite: function(info, context) {
+                    console.log('clickz');
                 var appCard = this;
                 var params = {};
                 if(info.module_name) {
@@ -438,40 +457,14 @@ define([
             },
 
 
-
-            populateAppListWithMethods: function() {
+            apps:null,
+            populateAppList: function(tag) {
                 var self = this;
 
                 // determine which set of methods to fetch
-                var tag='release'; // default is to show only 'release' tagged modules
-                if(self.options.tag) {
-                    tag = self.options.tag;
-                    if(tag!=='dev' && tag!=='beta' && tag!=='release') {
-                        console.warn('tag '+tag+ ' is not valid! Use: dev/beta/release.  defaulting to release.');
-                        tag='release';
-                    }
-                }
-
-                return self.nms.list_methods({
-                        tag:tag
-                    })
-                    .then(function (methods) {
-                        for(var k=0; k<methods.length; k++) {
-
-                            if(methods[k].loading_error) {
-                                console.log('Error in spec, will not be loaded:')
-                                console.log(methods[k])
-                                continue;
-                            }
-
-                            // logic to hide/show certain categories
-                            if(self.util.skipApp(methods[k].categories)) continue;
-
-                            var m = new AppCard('method',methods[k],tag,self.nms_base_url, 
-                                self.toggleFavorite, {catalog:self.catalog, browserWidget:self},
-                                self.runtime.service('session').isLoggedIn());
-                            self.appList.push(m);
-                        }
+                return self.nms.list_methods({tag:tag})
+                    .then(function (apps) {
+                        self.apps = apps;
                     })
                     .catch(function (err) {
                         console.error('ERROR');
@@ -479,18 +472,14 @@ define([
                     });
             },
 
-            populateAppListWithApps: function() {
+            legacyApps:null,
+            populateAppListWithLegacyApps: function() {
                 var self = this;
 
                 // apps cannot be registered via the SDK, so don't have tag info
                 return self.nms.list_apps({})
-                    .then(function (apps) {
-                        //console.log(apps);
-                        for(var k=0; k<apps.length; k++) {
-                            if(self.util.skipApp(apps[k].categories)) continue;
-                            var a = new AppCard('app',apps[k],null,self.nms_base_url);
-                            self.appList.push(a);
-                        }
+                    .then(function (legacyApps) {
+                        self.legacyApps = legacyApps;
                     })
                     .catch(function (err) {
                         console.error('ERROR');
@@ -499,8 +488,9 @@ define([
             },
 
 
+            moduleLookup: null,
 
-            populateModuleList: function() {
+            populateModuleList: function(only_released) {
                 var self = this
 
                 var moduleSelection = {
@@ -508,16 +498,16 @@ define([
                     include_unreleased:1,
                     include_disabled:0
                 };
+                if(only_released && only_released==true) {
+                    moduleSelection['include_unreleased']=0;
+                }
 
                 return self.catalog.list_basic_module_info(moduleSelection)
                     .then(function (modules) {
+                        self.moduleLookup = {}; // {module_name: {info:{}, hash1:'tag', hash:'tag', ...} 
+                        var tags = ['release', 'beta', 'dev'];
                         for(var k=0; k<modules.length; k++) {
-                            var m = {
-                                info: modules[k],
-                                $div: $('<div>').addClass('kbcb-module')
-                            };
-                            self.renderModuleBox(m);
-                            self.moduleList.push(m);
+                            self.moduleLookup[modules[k]['module_name']] = modules[k];
                         }
                     })
                     .catch(function (err) {
@@ -552,6 +542,19 @@ define([
                     });
             },
 
+            isDeveloper: function() {
+                var self = this
+
+                return self.catalog.is_approved_developer([self.runtime.service('session').getUsername()])
+                    .then(function (isDev) {
+                        console.log('isdev:',isDev)
+                    })
+                    .catch(function (err) {
+                        console.error('ERROR');
+                        console.error(err);
+                    });
+            },
+
 
             updateFavoritesCounts: function() {
                 var self = this
@@ -578,7 +581,7 @@ define([
             // warning!  will not return a promise if the user is not logged in!
             updateMyFavorites: function() {
                 var self = this
-                if(self.runtime.service('session').isLoggedIn()) {
+                if(self.isLoggedIn) {
                     return self.catalog.list_favorites(self.runtime.service('session').getUsername())
                         .then(function (favorites) {
                             self.favoritesList = favorites;
@@ -604,22 +607,74 @@ define([
             processData: function() {
                 var self = this;
 
-                // setup module map
-                self.moduleLookup = {};
+
+                // module lookup table should already exist
+
+
+                // instantiate the app cards and create the app lookup table
                 self.appLookup = {};
-                for(var m=0; m<self.moduleList.length; m++) {
-                    self.moduleLookup[self.moduleList[m].info.module_name] = self.moduleList[m];
-                }
-                for(var a=0; a<self.appList.length; a++) {
-                    // only lookup for methods; apps are deprecated
-                    if(self.appList[a].type==='method') {
-                        if(self.appList[a].info.module_name) {
-                            var idTokens = self.appList[a].info.id.split('/');
-                            self.appLookup[idTokens[0].toLowerCase() + '/' + idTokens[1]] = self.appList[a];
-                        } else {
-                            self.appLookup[self.appList[a].info.id] = self.appList[a];
+
+                for(var k=0; k<self.apps.length; k++) {
+
+                    if(self.apps[k].loading_error) {
+                        console.warn('Error in spec, will not be loaded:', self.apps[k])
+                        continue;
+                    }
+
+                    // logic to hide/show certain categories
+                    if(self.util.skipApp(self.apps[k].categories)) continue;
+
+                    // if we are showing dev/beta, do not show non-sdk methods
+                    if(self.options.tag!=='release') {
+                        if(!self.apps[k]['module_name']) {
+                            continue;
                         }
                     }
+
+
+                    //    legacy : true | false // indicates if this is a legacy App or SDK App
+                    //    app:  { .. }  // app info returned (for now) from NMS
+                    //    module: { .. }  // module info returned for SDK methods
+                    //    favoritesCallback: function () // function called when favorites button is clicked
+                    //    favoritesCallbackParams: {} // parameters passed on to the callback function
+                    //    isLoggedIn: true | false
+
+                    var m = new AppCard({
+                                    legacy:false,
+                                    app:self.apps[k],
+                                    module:self.moduleLookup[self.apps[k]['module_name']],
+                                    nms_base_url: self.nms_base_url, 
+                                    favoritesCallback: self.toggleFavorite, 
+                                    favoritesCallbackParams: {catalog:self.catalog, browserWidget:self},
+                                    isLoggedIn: self.isLoggedIn,
+                                    showReleaseTagLabels: self.showReleaseTagLabels,
+                                    linkTag: self.options.tag
+                                });
+                    self.appList.push(m);
+
+                    if(m.info.module_name) {
+                        var idTokens = m.info.id.split('/');
+                        self.appLookup[idTokens[0].toLowerCase() + '/' + idTokens[1]] = m;
+                    } else {
+                        self.appLookup[m.info.id] = m;
+                    }
+                }
+
+                // HANDLE LEGACY APPS!!
+                for(var k=0; k<self.legacyApps.length; k++) {
+                    if(self.legacyApps[k].loading_error) {
+                        console.warn('Error in spec, will not be loaded:', self.legacyApps[k])
+                        continue;
+                    }
+                    if(self.util.skipApp(self.legacyApps[k].categories)) continue;
+                    var a = new AppCard({
+                                    legacy:true,
+                                    app:self.legacyApps[k],
+                                    nms_base_url:self.nms_base_url,
+                                    isLoggedIn: self.isLoggedIn,
+                                    linkTag: self.options.tag
+                                });
+                    self.appList.push(a);
                 }
 
                 self.developers = {};
@@ -648,20 +703,7 @@ define([
                         }
                     }
                 }
-
-
-
             },
-
-
-
-
-            renderModuleBox: function(module) {
-                var $modDiv = $('<div>').addClass('kbcb-app');
-                $modDiv.append(module.info.module_name);
-                module.$div = $modDiv;
-            },
-
 
 
             renderAppList: function(organizeBy) {

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogFunctionBrowser.js
@@ -211,8 +211,8 @@ define([
 
                 var $registerLink = $('<li>').append($('<a href="#catalog/register">').append('<i class="fa fa-plus-circle"></i> Add Module'));
 
-                var $helpLink = $('<li>').append($('<a href="#catalog">').append('<i class="fa fa-question-circle"></i> Help'));
-
+                var $indexLink = $('<li>').append($('<a href="#catalog">').append('<i class="fa fa-bars"></i> Index'));
+                var $helpLink = $('<li>').append($('<a href="https://kbase.us/apps">').append('<i class="fa fa-question-circle"></i> Help'));
 
                 // PLACE CONTENT ON CONTROL BAR
                 $content
@@ -221,6 +221,7 @@ define([
                         .append($version)
                         .append($statusLink)
                         .append($registerLink)
+                        .append($indexLink)
                         .append($helpLink));
 
                 $nav.append($container)

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleViewer.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogModuleViewer.js
@@ -672,30 +672,34 @@ define([
                     .then(function(info_list) {
                         for(var k=0; k<info_list.length; k++) {
                             // logic to hide/show certain categories
+
                             if(self.util.skipApp(info_list[k].categories)) continue;
-                            
-                            var m = new AppCard('method',info_list[k],tag,self.nms_base_url,
-                                self.toggleFavorite, {catalog:self.catalog, browserWidget:self},
-                                self.runtime.service('session').isLoggedIn());
+                            var m = new AppCard({
+                                        legacy:false,
+                                        app:info_list[k],
+                                        module:self.moduleDetails.info,
+                                        nms_base_url: self.nms_base_url, 
+                                        favoritesCallback: self.toggleFavorite, 
+                                        favoritesCallbackParams: {catalog:self.catalog, browserWidget:self},
+                                        isLoggedIn: self.runtime.service('session').isLoggedIn(),
+                                        showReleaseTagLabels: true,
+                                        linkTag:info_list[k].git_commit_hash
+                                    });
                             self.appList.push(m);
-                        }
-                        for(var a=0; a<self.appList.length; a++) {
-                            // only lookup for methods; apps are deprecated
-                            if(self.appList[a].type==='method') {
-                                if(self.appList[a].info.module_name) {
-                                    var idTokens = self.appList[a].info.id.split('/');
-                                    self.appLookup[idTokens[0].toLowerCase() + '/' + idTokens[1]] = self.appList[a];
+                            if(m.info.module_name) {
+                                if(m.info.module_name) {
+                                    var idTokens = m.info.id.split('/');
+                                    self.appLookup[idTokens[0].toLowerCase() + '/' + idTokens[1]] = m;
                                 } else {
-                                    self.appLookup[self.appList[a].info.id] = self.appList[a];
+                                    self.appLookup[m.info.id] = m;
                                 }
                             }
                         }
-                        console.log('has functions!')
+
                         // do the same for local functions
                         if(has_functions) {
                             return self.catalog.list_local_functions({'release_tag': tag, 'module_names': [ self.module_name.toLowerCase() ] })
                                 .then(function(mods) {
-                                    console.log(mods)
                                     for(var m=0; m<mods.length; m++) {
                                         var f = new FunctionCard(mods[m],self.runtime.service('session').isLoggedIn());
                                         self.functionList.push(f);


### PR DESCRIPTION
Added a number of minor changes.  Most notably, the app browser will now only show certain menu options, including showing non-released versions, to developers.  This should keep things simpler for users, but we can take a look on CI and see if we like it.  The Apps are also now tagged with badges indicating the dev/beta/release version tags, and when beta/dev versions are selected, only those tagged as beta/dev are shown (previously, released versions of non-sdk apps were always shown).