### PR TITLE
Minor update to dynamic service log view

### DIFF
--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogService.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogService.js
@@ -364,8 +364,8 @@ define([
                 $container.append($('<i>').addClass('fa fa-spinner fa-2x fa-spin')).append('<br><br><br>');
                 self.$logPanelDiv.append($container);
 
-
-                if ('WebSocket' in window){
+                /* don't use websockets to rancher for now */
+                if (false) { //'WebSocket' in window){
                     /* WebSocket is supported. great! */
                     return self.wizard.get_service_log_web_socket({
                             service: {


### PR DESCRIPTION
For now our rancher instance is not public, so we can't use websockets to get dynamic service logs.  This reverts to a method that routes through the service_wizard, which works fine but requires manual refreshes of the log.