### PR TITLE
Disable demo plugin, increase module load timeout

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -86,13 +86,13 @@ plugins:
         cwd: src/plugin
         source:
             bower: {}
-    -
-        name: dataapidemo
-        globalName: kbase-ui-plugin-data-api-demo
-        version: 0.1.5
-        cwd: src/plugin
-        source:
-            bower: {}
+#    -
+#        name: dataapidemo
+#        globalName: kbase-ui-plugin-data-api-demo
+#        version: 0.1.5
+#        cwd: src/plugin
+#        source:
+#            bower: {}
     -
         name: shockbrowser
         globalName: kbase-ui-plugin-shockbrowser

--- a/src/client/require-config.js
+++ b/src/client/require-config.js
@@ -1,6 +1,7 @@
 var require = {
     baseUrl: '/modules',
     catchError: true,
+    waitSeconds: 60,
     paths: {
         // External Dependencies
         // ----------------------


### PR DESCRIPTION
- the data api demo was breaking the dev build since the inclusion of the data api alpha version. Since the ui build uses explicit versions, the packages used must be flexible enough to accommodate the specific versions required. However, since unreleased versions are not considered by bower (or npm) in a version expression like ^1.0.0 which is used by the demo package, bower cannot be satisfied, since the version in the ui is 1.0.6-alpha and the most recent version that can be satisfied by the demo is 1.0.5
- on slow connections the default module loading timeout of 7 seconds (per module) can cause errors. Increasing the limit to 60 seconds solves this problem. Further solutions will be explored, including a slowness detector. If modules take up tot 60 seconds to load, there will be severe problems using the ui anyway. However, for now the 60 second limit will make the ui more tolerant of temporary glitches in module loading.