### PR TITLE
Make default app sort 'category' rather than 'favorites'

### DIFF
--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogBrowser.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogBrowser.js
@@ -133,7 +133,9 @@ define([
                     self.updateFavoritesCounts()
                         .then(function() {
                             self.hideLoading();
-                            self.renderAppList('favorites');
+                            //self.renderAppList('favorites');               
+                            // Instead of making the default sort by # of favorites, sort by category (more intuitive to users)
+                            self.renderAppList('category');
                             return Promise.all([self.updateRunStats(),self.updateMyFavorites()]);
                         }).catch(function (err) {
                             console.error('ERROR');


### PR DESCRIPTION
As per https://atlassian.kbase.us/browse/KBASE-4579, users found the sort by # of favorites unintuitive. (Maybe it will be more useful in the future when we have more social features.)
Now the default sort should be by app category.
(I hope I did this right--not sure how to test it until it's on CI!)