### PR TITLE
Updates to dataview, datawidgets, bulk-ui, dashboard, narrative manager

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -39,7 +39,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.7.1
+        version: 1.8.0
         cwd: src/plugin
         source:
             bower: {}
@@ -75,7 +75,7 @@ plugins:
     -
         name: datawidgets
         globalName: kbase-ui-plugin-datawidgets
-        version: 0.2.2
+        version: 0.3.0
         cwd: src/plugin
         source:
             bower: {}
@@ -131,7 +131,7 @@ plugins:
     -
         name: bulk-ui
         globalName: kbase-ui-plugin-bulk-ui
-        version: 0.2.1
+        version: 0.2.2
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -46,7 +46,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.2.0
+        version: 1.2.2
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/dev/settings.yml
+++ b/config/ui/dev/settings.yml
@@ -32,7 +32,7 @@ docsite:
 menus:
     authenticated:
         main: [narrative, appcatalog, search, dashboard, bulk-ui]
-        developer: [sdkclientstest, dataapidemo, databrowser, typebrowser, jobbrowser, shockbrowser, test, visdemoBarchart, visdemoHeatmap, visdemoLinechart, visdemoScatterplot]
+        developer: [sdkclientstest, dataapidemo, databrowser, typebrowser, jobbrowser, shockbrowser, visdemoBarchart, visdemoHeatmap, visdemoLinechart, visdemoScatterplot]
         help: [contact-kbase, about-kbase]
     unauthenticated:
         main: [appcatalog, search]

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -50,7 +50,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.2.0
+        version: 1.2.2
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -36,14 +36,14 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.7.1
+        version: 1.8.0
         cwd: src/plugin
         source:
             bower: {}
     -
         name: datawidgets
         globalName: kbase-ui-plugin-datawidgets
-        version: 0.2.2
+        version: 0.3.0
         cwd: src/plugin
         source:
             bower: {}
@@ -78,7 +78,7 @@ plugins:
     -
         name: bulk-ui
         globalName: kbase-ui-plugin-bulk-ui
-        version: 0.2.1
+        version: 0.2.2
         cwd: src/plugin
         source:
             bower: {}

--- a/src/client/data/metrics/narrative_histogram.json
+++ b/src/client/data/metrics/narrative_histogram.json
@@ -1,117 +1,117 @@
 {
     "meta": {
-        "generated": 1424337784,
-        "originalGenerated": 1424338753
+        "generated": 1476144280,
+        "originalGenerated": 1476100064
     },
     "histogram": {
         "summary": {
             "min": 1,
-            "max": 41,
-            "mean": 5.0431654676259,
-            "count": 139,
+            "max": 95,
+            "mean": 5.2272047832586,
+            "count": 669,
             "median": 2,
-            "stddev": 21951.198968605,
+            "stddev": 1257378243679,
             "lq": 1,
-            "uq": 5,
-            "iqr": 4
+            "uq": 4.5,
+            "iqr": 3.5
         },
         "bins": [
             {
-                "count": 71,
+                "count": 411,
                 "label": "[1-3)",
                 "upperInclusive": false,
                 "lower": 1,
                 "upper": 3
             },
             {
-                "count": 16,
+                "count": 91,
                 "label": "[3-5)",
                 "upperInclusive": false,
                 "lower": 3,
                 "upper": 5
             },
             {
-                "count": 27,
+                "count": 39,
                 "label": "[5-7)",
                 "upperInclusive": false,
                 "lower": 5,
                 "upper": 7
             },
             {
-                "count": 6,
+                "count": 36,
                 "label": "[7-9)",
                 "upperInclusive": false,
                 "lower": 7,
                 "upper": 9
             },
             {
-                "count": 4,
+                "count": 19,
                 "label": "[9-11)",
                 "upperInclusive": false,
                 "lower": 9,
                 "upper": 11
             },
             {
-                "count": 1,
+                "count": 13,
                 "label": "[11-13)",
                 "upperInclusive": false,
                 "lower": 11,
                 "upper": 13
             },
             {
-                "count": 2,
+                "count": 9,
                 "label": "[13-15)",
                 "upperInclusive": false,
                 "lower": 13,
                 "upper": 15
             },
             {
-                "count": 2,
+                "count": 7,
                 "label": "[15-17)",
                 "upperInclusive": false,
                 "lower": 15,
                 "upper": 17
             },
             {
-                "count": 1,
+                "count": 4,
                 "label": "[17-19)",
                 "upperInclusive": false,
                 "lower": 17,
                 "upper": 19
             },
             {
-                "count": 3,
+                "count": 5,
                 "label": "[19-21]",
                 "upperInclusive": true,
                 "lower": 19,
                 "upper": 21
             },
             {
-                "count": 6,
-                "label": "(21-41]",
+                "count": 35,
+                "label": "(21-95]",
                 "upperInclusive": true,
                 "lower": 21,
-                "upper": 41
+                "upper": 95
             }
         ],
-        "lowerIQR": -10,
-        "upperIQR": 14,
+        "lowerIQR": -8.5,
+        "upperIQR": 12.5,
         "lowerBound": 1,
         "upperBound": 21,
         "binSize": 2,
         "binCount": 10,
         "binned": [
-            71,
-            16,
-            27,
-            6,
+            411,
+            91,
+            39,
+            36,
+            19,
+            13,
+            9,
+            7,
             4,
-            1,
-            2,
-            2,
-            1,
-            3,
-            6
+            5,
+            35
         ],
         "labels": [
             "[1-3)",
@@ -124,29 +124,56 @@
             "[15-17)",
             "[17-19)",
             "[19-21]",
-            "(21-41]"
+            "(21-95]"
         ],
-        "below": [
-
-        ],
+        "below": [],
         "above": [
-            29,
-            25,
-            33,
-            41,
             27,
-            26
+            41,
+            32,
+            27,
+            59,
+            26,
+            28,
+            57,
+            39,
+            57,
+            95,
+            76,
+            42,
+            28,
+            68,
+            35,
+            82,
+            36,
+            31,
+            39,
+            25,
+            38,
+            26,
+            36,
+            38,
+            25,
+            31,
+            40,
+            24,
+            24,
+            68,
+            28,
+            56,
+            33,
+            35
         ]
     },
     "summary": {
         "min": 1,
-        "max": 41,
-        "mean": 5.0431654676259,
-        "count": 139,
+        "max": 95,
+        "mean": 5.2272047832586,
+        "count": 669,
         "median": 2,
-        "stddev": 21951.198968605,
+        "stddev": 1257378243679,
         "lq": 1,
-        "uq": 5,
-        "iqr": 4
+        "uq": 4.5,
+        "iqr": 3.5
     }
 }

--- a/src/client/data/metrics/narrative_shared_histogram.json
+++ b/src/client/data/metrics/narrative_shared_histogram.json
@@ -1,150 +1,154 @@
 {
     "meta": {
-        "generated": 1424337784,
-        "originalGenerated": 1424338753
+        "generated": 1476144280,
+        "originalGenerated": 1476100064
     },
     "histogram": {
         "summary": {
             "min": 1,
-            "max": 22,
-            "mean": 3.4333333333333,
-            "count": 90,
+            "max": 56,
+            "mean": 5.0111524163569,
+            "count": 269,
             "median": 2,
-            "stddev": 66.154353405461,
+            "stddev": 2896149.8184371,
             "lq": 1,
-            "uq": 4,
-            "iqr": 3
+            "uq": 5,
+            "iqr": 4
         },
         "bins": [
             {
-                "count": 37,
-                "label": "[1-2)",
+                "count": 150,
+                "label": "[1-3)",
                 "upperInclusive": false,
                 "lower": 1,
-                "upper": 2
-            },
-            {
-                "count": 16,
-                "label": "[2-3)",
-                "upperInclusive": false,
-                "lower": 2,
                 "upper": 3
             },
             {
-                "count": 11,
-                "label": "[3-4)",
+                "count": 41,
+                "label": "[3-5)",
                 "upperInclusive": false,
                 "lower": 3,
-                "upper": 4
-            },
-            {
-                "count": 5,
-                "label": "[4-5)",
-                "upperInclusive": false,
-                "lower": 4,
                 "upper": 5
             },
             {
-                "count": 4,
-                "label": "[5-6)",
+                "count": 25,
+                "label": "[5-7)",
                 "upperInclusive": false,
                 "lower": 5,
-                "upper": 6
-            },
-            {
-                "count": 3,
-                "label": "[6-7)",
-                "upperInclusive": false,
-                "lower": 6,
                 "upper": 7
             },
             {
-                "count": 3,
-                "label": "[7-8)",
+                "count": 9,
+                "label": "[7-9)",
                 "upperInclusive": false,
                 "lower": 7,
-                "upper": 8
-            },
-            {
-                "count": 3,
-                "label": "[8-9)",
-                "upperInclusive": false,
-                "lower": 8,
                 "upper": 9
             },
             {
-                "count": 1,
-                "label": "[9-10)",
+                "count": 6,
+                "label": "[9-11)",
                 "upperInclusive": false,
                 "lower": 9,
-                "upper": 10
-            },
-            {
-                "count": 3,
-                "label": "[10-11]",
-                "upperInclusive": true,
-                "lower": 10,
                 "upper": 11
             },
             {
-                "count": 4,
-                "label": "(11-22]",
-                "upperInclusive": true,
+                "count": 6,
+                "label": "[11-13)",
+                "upperInclusive": false,
                 "lower": 11,
-                "upper": 22
+                "upper": 13
+            },
+            {
+                "count": 13,
+                "label": "[13-15)",
+                "upperInclusive": false,
+                "lower": 13,
+                "upper": 15
+            },
+            {
+                "count": 3,
+                "label": "[15-17)",
+                "upperInclusive": false,
+                "lower": 15,
+                "upper": 17
+            },
+            {
+                "count": 3,
+                "label": "[17-19)",
+                "upperInclusive": false,
+                "lower": 17,
+                "upper": 19
+            },
+            {
+                "count": 3,
+                "label": "[19-21]",
+                "upperInclusive": true,
+                "lower": 19,
+                "upper": 21
+            },
+            {
+                "count": 10,
+                "label": "(21-56]",
+                "upperInclusive": true,
+                "lower": 21,
+                "upper": 56
             }
         ],
-        "lowerIQR": -7,
-        "upperIQR": 11,
+        "lowerIQR": -10,
+        "upperIQR": 14,
         "lowerBound": 1,
-        "upperBound": 11,
-        "binSize": 1,
+        "upperBound": 21,
+        "binSize": 2,
         "binCount": 10,
         "binned": [
-            37,
-            16,
-            11,
-            5,
-            4,
+            150,
+            41,
+            25,
+            9,
+            6,
+            6,
+            13,
             3,
             3,
             3,
-            1,
-            3,
-            4
+            10
         ],
         "labels": [
-            "[1-2)",
-            "[2-3)",
-            "[3-4)",
-            "[4-5)",
-            "[5-6)",
-            "[6-7)",
-            "[7-8)",
-            "[8-9)",
-            "[9-10)",
-            "[10-11]",
-            "(11-22]"
+            "[1-3)",
+            "[3-5)",
+            "[5-7)",
+            "[7-9)",
+            "[9-11)",
+            "[11-13)",
+            "[13-15)",
+            "[15-17)",
+            "[17-19)",
+            "[19-21]",
+            "(21-56]"
         ],
-        "below": [
-
-        ],
+        "below": [],
         "above": [
-            15,
+            34,
+            47,
+            56,
+            35,
             22,
-            14,
-            12
+            37,
+            33,
+            49,
+            23,
+            22
         ]
     },
     "summary": {
         "min": 1,
-        "max": 22,
-        "mean": 3.4333333333333,
-        "count": 90,
+        "max": 56,
+        "mean": 5.0111524163569,
+        "count": 269,
         "median": 2,
-        "stddev": 66.154353405461,
+        "stddev": 2896149.8184371,
         "lq": 1,
-        "uq": 4,
-        "iqr": 3
+        "uq": 5,
+        "iqr": 4
     }
 }

--- a/src/client/data/metrics/narrative_sharing_histogram.json
+++ b/src/client/data/metrics/narrative_sharing_histogram.json
@@ -1,58 +1,58 @@
 {
     "meta": {
-        "generated": 1424337785,
-        "originalGenerated": 1424338753
+        "generated": 1476144777,
+        "originalGenerated": 1476100064
     },
     "histogram": {
         "summary": {
             "min": 1,
-            "max": 20,
-            "mean": 3.046511627907,
-            "count": 43,
+            "max": 34,
+            "mean": 3.7307692307692,
+            "count": 156,
             "median": 2,
-            "stddev": 54.365089531403,
+            "stddev": 3150.1490944072,
             "lq": 1,
-            "uq": 3.5,
-            "iqr": 2.5
+            "uq": 3,
+            "iqr": 2
         },
         "bins": [
             {
-                "count": 19,
+                "count": 73,
                 "label": "[1-2)",
                 "upperInclusive": false,
                 "lower": 1,
                 "upper": 2
             },
             {
-                "count": 7,
+                "count": 28,
                 "label": "[2-3)",
                 "upperInclusive": false,
                 "lower": 2,
                 "upper": 3
             },
             {
-                "count": 7,
+                "count": 18,
                 "label": "[3-4)",
                 "upperInclusive": false,
                 "lower": 3,
                 "upper": 4
             },
             {
-                "count": 1,
+                "count": 8,
                 "label": "[4-5)",
                 "upperInclusive": false,
                 "lower": 4,
                 "upper": 5
             },
             {
-                "count": 3,
+                "count": 1,
                 "label": "[5-6)",
                 "upperInclusive": false,
                 "lower": 5,
                 "upper": 6
             },
             {
-                "count": 1,
+                "count": 8,
                 "label": "[6-7)",
                 "upperInclusive": false,
                 "lower": 6,
@@ -73,45 +73,45 @@
                 "upper": 9
             },
             {
-                "count": 1,
+                "count": 4,
                 "label": "[9-10)",
                 "upperInclusive": false,
                 "lower": 9,
                 "upper": 10
             },
             {
-                "count": 0,
+                "count": 1,
                 "label": "[10-11]",
                 "upperInclusive": true,
                 "lower": 10,
                 "upper": 11
             },
             {
-                "count": 1,
-                "label": "(11-20]",
+                "count": 12,
+                "label": "(11-34]",
                 "upperInclusive": true,
                 "lower": 11,
-                "upper": 20
+                "upper": 34
             }
         ],
-        "lowerIQR": -5.5,
-        "upperIQR": 9.5,
+        "lowerIQR": -4,
+        "upperIQR": 8,
         "lowerBound": 1,
         "upperBound": 11,
         "binSize": 1,
         "binCount": 10,
         "binned": [
-            19,
-            7,
-            7,
+            73,
+            28,
+            18,
+            8,
             1,
-            3,
-            1,
+            8,
             1,
             2,
+            4,
             1,
-            0,
-            1
+            12
         ],
         "labels": [
             "[1-2)",
@@ -124,24 +124,33 @@
             "[8-9)",
             "[9-10)",
             "[10-11]",
-            "(11-20]"
+            "(11-34]"
         ],
-        "below": [
-
-        ],
+        "below": [],
         "above": [
-            20
+            12,
+            31,
+            34,
+            15,
+            24,
+            16,
+            14,
+            30,
+            12,
+            16,
+            27,
+            13
         ]
     },
     "summary": {
         "min": 1,
-        "max": 20,
-        "mean": 3.046511627907,
-        "count": 43,
+        "max": 34,
+        "mean": 3.7307692307692,
+        "count": 156,
         "median": 2,
-        "stddev": 54.365089531403,
+        "stddev": 3150.1490944072,
         "lq": 1,
-        "uq": 3.5,
-        "iqr": 2.5
+        "uq": 3,
+        "iqr": 2
     }
 }

--- a/src/client/modules/plugins/narrativemanager/config.yml
+++ b/src/client/modules/plugins/narrativemanager/config.yml
@@ -31,6 +31,13 @@ install:
             module: ./createNewPanel
             id: narrativeManager_createNew
             type: factory
+    menu:
+        -
+            name: narrative
+            definition:
+                path: narrativemanager/start
+                label: Narrative Interface
+                icon: file 
     routes:
         -
             path: [narrativemanager, start]

--- a/src/client/modules/plugins/welcome/config.yml
+++ b/src/client/modules/plugins/welcome/config.yml
@@ -65,9 +65,4 @@ install:
                 newWindow: true
                 label: Contact KBase
                 icon: envelope-o
-        -
-            name: narrative
-            definition:
-                path: narrativemanager/start
-                label: Narrative
-                icon: file                    
+                   


### PR DESCRIPTION
- dataview now registers (again) the tree widget
- datawidgets does not register the tree widget
- remove datawidgets testing menu item and route from dev build
- update bulk-ui dep to pick up normalized labeling
- dashboard metrics base comparison files updated
- move narrative start menu item from welcome plugin to the narrative manager plugin