### PR TITLE
add help menu item

### DIFF
--- a/config/ui/dev/settings.yml
+++ b/config/ui/dev/settings.yml
@@ -33,8 +33,8 @@ menus:
     authenticated:
         main: [narrative, appcatalog, search, dashboard, bulk-ui]
         developer: [sdkclientstest, dataapidemo, databrowser, typebrowser, jobbrowser, shockbrowser, visdemoBarchart, visdemoHeatmap, visdemoLinechart, visdemoScatterplot]
-        help: [contact-kbase, about-kbase]
+        help: [contact-kbase, about-kbase, help]
     unauthenticated:
         main: [appcatalog, search]
         developer: []
-        help: [contact-kbase, about-kbase]
+        help: [contact-kbase, about-kbase, help]

--- a/config/ui/prod/settings.yml
+++ b/config/ui/prod/settings.yml
@@ -34,8 +34,8 @@ menus:
     authenticated: 
         main: [narrative, appcatalog, search, dashboard, bulk-ui]
         developer: []
-        help: [contact-kbase, about-kbase]
+        help: [contact-kbase, about-kbase, help]
     unauthenticated: 
         main: [appcatalog, search]
         developer: []
-        help: [contact-kbase, about-kbase]
+        help: [contact-kbase, about-kbase, help]

--- a/src/client/modules/plugins/welcome/config.yml
+++ b/src/client/modules/plugins/welcome/config.yml
@@ -65,4 +65,11 @@ install:
                 newWindow: true
                 label: Contact KBase
                 icon: envelope-o
+        -
+            name: help
+            definition:
+                uri: https://kbase.us/narrative-guide/
+                newWindow: true
+                label: Help
+                icon: question
                    


### PR DESCRIPTION
- updated the "welcome" plugin which contains the core menu items to
  provide the help menu item definition
- updated the kbase-ui config to insert the help menu item on dev and
  prod menus in both authenticated and unauthenticated states.
- addresses https://atlassian.kbase.us/browse/KBASE-4185