### PR TITLE
JGI import to new narrative no longer adds app, rather markdown instructions

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -39,7 +39,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.8.0
+        version: 2.0.0
         cwd: src/plugin
         source:
             bower: {}
@@ -132,6 +132,13 @@ plugins:
         name: bulk-ui
         globalName: kbase-ui-plugin-bulk-ui
         version: 0.2.2
+        cwd: src/plugin
+        source:
+            bower: {}
+    -
+        name: jgi-import
+        globalName: kbase-ui-plugin-jgi-import
+        version: 0.1.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -36,7 +36,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 1.8.0
+        version: 2.0.0
         cwd: src/plugin
         source:
             bower: {}
@@ -79,6 +79,13 @@ plugins:
         name: bulk-ui
         globalName: kbase-ui-plugin-bulk-ui
         version: 0.2.2
+        cwd: src/plugin
+        source:
+            bower: {}    
+    -
+        name: jgi-import
+        globalName: kbase-ui-plugin-jgi-import
+        version: 0.1.0
         cwd: src/plugin
         source:
             bower: {}

--- a/src/client/modules/plugins/narrativemanager/config.yml
+++ b/src/client/modules/plugins/narrativemanager/config.yml
@@ -54,6 +54,7 @@ install:
             queryParams:
                 app: {}
                 method: {}
+                markdown: {}
                 copydata: {}
                 appparam: {} 
             widget: narrativeManager_createNew

--- a/src/client/modules/plugins/narrativemanager/modules/createNewPanel.js
+++ b/src/client/modules/plugins/narrativemanager/modules/createNewPanel.js
@@ -42,10 +42,14 @@ define([
                         }
                     }
                 }
+                
+                // Note that these are exclusive cell creation options. 
                 if (params.app) {
                     cells = [{app: params.app}];
                 } else if (params.method) {
                     cells = [{method: params.method}];
+                } else if (params.markdown) {
+                    cells = [{markdown: params.markdown}];
                 }
                 
                 return narrativeManager.createTempNarrative({

--- a/src/client/modules/plugins/narrativemanager/modules/narrativeManager.js
+++ b/src/client/modules/plugins/narrativemanager/modules/narrativeManager.js
@@ -429,9 +429,7 @@ define([
                             // 2 - create the Narrative object
                             return fetchNarrativeObjects(workspaceName, params.cells, params.parameters);
                         })
-                        .then(function (result) {
-                            var narrativeObject = result[0],
-                                metadataExternal = result[1];
+                        .spread(function (narrativeObject, metadataExternal) {
                             // 3 - save the Narrative object
                             return workspaceClient.save_objects({
                                 workspace: workspaceName,

--- a/src/client/modules/startup.js
+++ b/src/client/modules/startup.js
@@ -181,6 +181,7 @@
         }
         main.start()
             .catch(function (err) {
+                console.error('Startup Error', err);
                 KBaseFallback.showError({
                     title: 'KBase Application Startup Error',
                     content: [
@@ -195,7 +196,6 @@
                     ]
                 });
                 // document.getElementById('root').innerHTML = 'Error starting KBase UI. Please consult the browser error log.';
-                // console.error('Startup Error', err);
             });
     }, function (err) {
         handleStartupError(err);


### PR DESCRIPTION
- the jgi import feature (#jgi/import/REF) allows the user to create a new narrative containing an object obtained via push-to-kbase.
- previously it would add a pre-selected app to the narrative as well to help the user get started.
- since those apps are now obsolete, and in general because we don't want to tie specific apps into code like that, we no l longer add the app to the narrative.
- rather, it now adds a markdown cell which has instructions on how to select an appropriate app
- at the same time, jgi-import moved from small piece of dataview to its own plugin repo.
- some changes to the narrative manager (an internal plugin) to allow creating a markdown cell
- addresses https://atlassian.kbase.us/browse/NAR-856