### PR TITLE
Updated dashboard and deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,7 +48,9 @@
     "postal": "1.0.7",
     "plotly": "plotly/plotly.js#1.5.1",
     "highlightjs": "9.2.0",
-    "marked": "0.3.6"
+    "marked": "0.3.6",
+    "kb_common": "kbase-common-js#2.0.0",
+    "kb_service": "kbase-service-clients-js#3.1.2"
   },
   "devDependencies": {},
   "license": "SEE LICENSE IN LICENSE"

--- a/config/bowerInstall.yml
+++ b/config/bowerInstall.yml
@@ -155,4 +155,14 @@ bowerFiles:
         cwd: dist
         src: plotly.js
         bowerComponent: true
+    -
+        name: kb_common
+        cwd: dist
+        src: "**/*"
+        bowerComponent: false
+    -
+        name: kb_service
+        cwd: dist
+        src: "**/*"
+        bowerComponent: false
             

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -48,7 +48,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.2.4
+        version: 2.0.4
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -50,7 +50,7 @@ plugins:
     -
         name: dashboard
         globalName: kbase-ui-plugin-dashboard
-        version: 1.2.4
+        version: 2.0.4
         cwd: src/plugin
         source:
             bower: {}
@@ -81,6 +81,7 @@ plugins:
         version: 0.2.2
         cwd: src/plugin
         source:
+
             bower: {}    
     -
         name: jgi-import

--- a/mutations/build.js
+++ b/mutations/build.js
@@ -216,6 +216,7 @@ function installModulePackagesFromBower(state) {
         })
         .then(function (installDirs) {
             return Promise.all(installDirs.map(function (installDir) {
+                // console.log('Installing module: ' + installDir.path);
                 return installModule(state, installDir.path);
             }));
         })
@@ -401,7 +402,7 @@ function copyFromBower(state) {
                 /*
                  Finally, the cwd serves as a way to dig into a subdirectory and use it as the 
                  basis for copying. This allows us to "bring up" files to the top level of 
-                 the destination. Since we are relative to the root of this proces, we
+                 the destination. Since we are relative to the root of this process, we
                  need to jigger that here.
                  */
                 if (cfg.cwd) {
@@ -902,6 +903,7 @@ function main(type) {
             return mutant.copyState(state);
         })
         .then(function (state) {
+            console.log('Installing Module Packages from Bower...');
             return installModulePackagesFromBower(state);
         })
 
@@ -972,7 +974,7 @@ function main(type) {
         })
         .catch(function (err) {
             console.log('ERROR');
-            // console.log(err);
+            console.log(err);
             console.log(util.inspect(err, {
                 showHidden: false,
                 depth: 10


### PR DESCRIPTION
- dashboard changes brought it to fix public narrative widget and display of apps, jobs (removed) and sharing
- added CDN/Narrative compatible kb_common and kb_service (existing ones remain as well.)
- updated build process to allow installation of multiple versions of a dep under different root dirs. This is to allow the single-rooted kbase deps, as used in the Narrative and in the CDN, to be installed directly here simultaneously with the older kb/PACKAGE rooted versions. This allows us to migrate to the single-rooted builds.