### PR TITLE
support for backup auth cookie

### DIFF
--- a/config/deploy/deploy-appdev.cfg
+++ b/config/deploy/deploy-appdev.cfg
@@ -7,6 +7,8 @@ deploy_environment=appdev
 deploy_hostname=appdev.kbase.us
 deploy_icon=wrench
 deploy_name=App Dev
+deploy_backup_cookie_enabled=0
+deploy_cookie_domain=kbase.us
 
 # Service Endpoints
 awe_url=https://appdev.kbase.us/services/awe-api

--- a/config/deploy/deploy-ci.cfg
+++ b/config/deploy/deploy-ci.cfg
@@ -7,6 +7,8 @@ deploy_environment=ci
 deploy_hostname=ci.kbase.us
 deploy_icon=flask
 deploy_name=Continuous Integration
+deploy_backup_cookie_enabled=0
+deploy_cookie_domain=kbase.us
 
 # Service Endpoints
 awe_url=https://ci.kbase.us/services/awe-api

--- a/config/deploy/deploy-ci.cfg
+++ b/config/deploy/deploy-ci.cfg
@@ -7,7 +7,7 @@ deploy_environment=ci
 deploy_hostname=ci.kbase.us
 deploy_icon=flask
 deploy_name=Continuous Integration
-deploy_backup_cookie_enabled=0
+deploy_backup_cookie_enabled=1
 deploy_cookie_domain=kbase.us
 
 # Service Endpoints

--- a/config/deploy/deploy-dev.cfg
+++ b/config/deploy/deploy-dev.cfg
@@ -7,6 +7,8 @@ deploy_environment=ci
 deploy_hostname=ci.kbase.us
 deploy_icon=flask
 deploy_name=Continuous Integration
+deploy_backup_cookie_enabled=0
+deploy_cookie_domain=kbase.us
 
 # Service Endpoints
 awe_url=https://ci.kbase.us/services/awe-api

--- a/config/deploy/deploy-local-dev.cfg
+++ b/config/deploy/deploy-local-dev.cfg
@@ -7,6 +7,8 @@ deploy_environment=local-dev
 deploy_hostname=local-dev.kbase.us
 deploy_icon=paper-plane
 deploy_name=Local Development
+deploy_backup_cookie_enabled=0
+deploy_cookie_domain=kbase.us
 
 # Service Endpoints
 awe_url=https://ci.kbase.us/services/awe-api

--- a/config/deploy/deploy-narrative-dev.cfg
+++ b/config/deploy/deploy-narrative-dev.cfg
@@ -7,6 +7,8 @@ deploy_environment=narrative-dev
 deploy_hostname=narrative-dev.kbase.us
 deploy_icon=space-shuttle
 deploy_name=Narrative Dev
+deploy_backup_cookie_enabled=0
+deploy_cookie_domain=kbase.us
 
 # Service Endpoints
 awe_url=https://kbase.us/services/awe-api

--- a/config/deploy/deploy-next.cfg
+++ b/config/deploy/deploy-next.cfg
@@ -7,6 +7,9 @@ deploy_environment=next
 deploy_hostname=next.kbase.us
 deploy_icon=bullseye
 deploy_name=Next
+deploy_backup_cookie_enabled=0
+deploy_cookie_domain=kbase.us
+
 
 # Service Endpoints
 awe_url=https://next.kbase.us/services/awe-api

--- a/config/deploy/deploy-prod.cfg
+++ b/config/deploy/deploy-prod.cfg
@@ -7,6 +7,8 @@ deploy_environment=prod
 deploy_hostname=kbase.us
 deploy_icon=thumbs-up
 deploy_name=Production
+deploy_backup_cookie_enabled=1
+deploy_cookie_domain=kbase.us
 
 # Service Endpoints
 awe_url=https://kbase.us/services/awe-api

--- a/config/deploy/templates/service.yml
+++ b/config/deploy/templates/service.yml
@@ -119,3 +119,5 @@ deploy:
     hostname: <%= deploy_hostname %>
     icon: <%= deploy_icon %>
     name: <%= deploy_name %>
+    cookie-domain: <%= deploy_cookie_domain %>
+    backup-cookie-enabled: <%= deploy_backup_cookie_enabled %>

--- a/src/client/modules/app/App.js
+++ b/src/client/modules/app/App.js
@@ -183,13 +183,22 @@ define([
 
         function begin() {
             // Register service handlers.
-            appServiceManager.addService('session', {
+            var sessionConfig = {
                 runtime: api,
-                cookieName: 'kbase_session',
+                cookieName: 'kbase_session',               
                 loginUrl: serviceConfig.services.login.url,
                 cookieMaxAge: clientConfig.ui.constants.session_max_age
+            };
+            if (api.config('deploy.backup-cookie-enabled')) {
+                sessionConfig.extraCookies = [
+                    {
+                        name: 'kbase_session_backup',
+                        domain: api.config('deploy.cookie-domain')
+                    }
+                ];
+            }
 
-            });
+            appServiceManager.addService('session', sessionConfig);
             appServiceManager.addService('heartbeat', {
                 runtime: api,
                 interval: 500

--- a/src/client/modules/app/services/session.js
+++ b/src/client/modules/app/services/session.js
@@ -9,6 +9,7 @@ define([
         var runtime = config.runtime,
             session = sessionFactory.make({
                 cookieName: config.cookieName,
+                extraCookies: config.extraCookies,
                 loginUrl: config.loginUrl,
                 cookieMaxAge: config.cookieMaxAge || 100000
             }),


### PR DESCRIPTION
- config files support the deploy_backup_cookie_enabled and deploy_cookie_domain properties
- config template service.yml supports deploy.cookie-domain and deploy.backup-cookie-enabled properties
- session.js (in kb_common) now supports (again) extra cookies to be created alongside kbase_session. Each extra cookie provides the name and (optional) domain.
- App.js provides the extra-cookies constructor data according to the new configuration
- session.js creates and deletes the extra cookies alongside the normal kbase_session cookie
- the deletion of all kbase.us domain cookies, in place to help provide a fully clean footprint in the browser upon login, has been disabled, since it would delete the new backup cookie in non-production environments.