### PR TITLE
added Auth2Error to require-config

### DIFF
--- a/src/search/js/require-config.js
+++ b/src/search/js/require-config.js
@@ -102,6 +102,7 @@ require.config({
 
       'Auth2Session' : '../modules/kb_common_ts/Auth2Session',
       'Auth2Error' : '../modules/kb_common_ts/Auth2Error',
+      'Auth2Client' : '../modules/kb_common_ts/Auth2Client',
       'Cookie' : '../modules/kb_common_ts/Cookie',
       'Auth2' : '../modules/kb_common_ts/Auth2',
       'bluebird' : '../modules/bower_components/bluebird/bluebird',

--- a/src/search/js/require-config.js
+++ b/src/search/js/require-config.js
@@ -101,6 +101,7 @@ require.config({
       'kb.client.methods': 'src/clients/kbaseClientMethods',
 
       'Auth2Session' : '../modules/kb_common_ts/Auth2Session',
+      'Auth2Error' : '../modules/kb_common_ts/Auth2Error',
       'Cookie' : '../modules/kb_common_ts/Cookie',
       'Auth2' : '../modules/kb_common_ts/Auth2',
       'bluebird' : '../modules/bower_components/bluebird/bluebird',

--- a/src/search/js/search.js
+++ b/src/search/js/search.js
@@ -1373,7 +1373,6 @@ searchApp.controller('searchController', function searchCtrl($rootScope, $scope,
     $scope.listWorkspaces = function() {
         try {
             $scope.options.userState.session.displayWorkspaces = true;
-            console.log("MAKES A WS WITH TOKEN", $scope.options.userState.session.token);
             $scope.workspace_service = searchKBaseClientsService.getWorkspaceClient($scope.options.userState.session.token);
             $scope.options.userState.longterm.workspaces = [];
 


### PR DESCRIPTION
It's tossing errors in CI because it has the wrong path for the Auth2Error module, which I didn't need for some reason in dev...

Added that in.

Dropped a debugging line while I was at it.