### PR TITLE
Improve new sidebar nav, reset feature for knockout-dirty

### DIFF
--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.11.1
+        version: 0.11.2
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -86,7 +86,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.11.1
+        version: 0.11.2
         cwd: src/plugin
         source:
             bower: {}

--- a/mutations/build.js
+++ b/mutations/build.js
@@ -965,14 +965,14 @@ function makeModuleVFS(state, whichBuild) {
     var root = state.environment.path,
         buildPath = ['..', 'build'];
 
-    return glob(root.concat(['dist', 'client', 'modules', '**', '*.js']).join('/'), {
+    return glob(root.concat([whichBuild, 'client', 'modules', '**', '*.js']).join('/'), {
             nodir: true
         })
         .then(function (matches) {
 
             // just read in file and build a giant map...            
             var vfs = {};
-            var vfsDest = buildPath.concat([whichBuild, 'moduleVfs.json']);
+            var vfsDest = buildPath.concat([whichBuild, 'moduleVfs.js']);
             //console.log('matches', JSON.stringify(matches));
             return Promise.all(matches
                     .map(function (match) {
@@ -1183,6 +1183,7 @@ function main(type) {
             // TODO: a build flag for the vfs.
             // FORNOW: no vfs build for dev
             var vfs = [];
+            vfs.push(makeModuleVFS(state, 'build'));
             if (state.config.build.dist) {
                 vfs.push(makeModuleVFS(state, 'dist'));
             }

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -11,7 +11,7 @@
     <script src="/build-info.js?cb={{git.abbreviatedSha}}"></script>
     <script src="/require-config.js?cb={{git.abbreviatedSha}}"></script>
     <script src="/modules/bower_components/requirejs/require.js?cb={{git.abbreviatedSha}}" data-main="startup"></script>
-    <!-- < xscript src="/moduleVfs.json"></xscript> -->
+    <!-- <script src="/moduleVfs.js"></script> -->
 </head>
 
 <body class="kbase-ui">

--- a/src/client/modules/lib/knockout-plus.js
+++ b/src/client/modules/lib/knockout-plus.js
@@ -7,6 +7,7 @@ define([
 
 
     ko.extenders.dirty = function (target, startDirty) {
+        var lastValue = target();
         var cleanValue = ko.observable(ko.mapping.toJSON(target));
         var dirtyOverride = ko.observable(ko.utils.unwrapObservable(startDirty));
 
@@ -16,10 +17,14 @@ define([
 
         target.markClean = function () {
             cleanValue(ko.mapping.toJSON(target));
+            lastValue = target();
             dirtyOverride(false);
         };
         target.markDirty = function () {
             dirtyOverride(true);
+        };
+        target.reset = function () {
+            target(lastValue);
         };
 
         return target;

--- a/src/client/modules/plugins/mainwindow/modules/mainWindow.js
+++ b/src/client/modules/plugins/mainwindow/modules/mainWindow.js
@@ -95,7 +95,13 @@ define([
                             }
                         }, [
                             div({ class: 'kb-mainwindow-alert' }, div({ id: widgetSet.addWidget('kb_mainWindow_alert') })),
-                            div({ class: 'kb-mainwindow-body', style: { 'padding-top': '1em' } }, [
+                            div({
+                                class: 'kb-mainwindow-body',
+                                style: {
+                                    paddingTop: '1em',
+                                    overflow: 'auto'
+                                }
+                            }, [
                                 div({ id: widgetSet.addWidget('body') })
                             ])
                         ])

--- a/src/client/modules/plugins/mainwindow/modules/sidebarNav.css
+++ b/src/client/modules/plugins/mainwindow/modules/sidebarNav.css
@@ -1,3 +1,7 @@
+.kb-mainWindow-sidebarNav {
+    position: fixed;
+}
+
 .kb-mainWindow-sidebarNav .-nav-button {
     background-color: transparent;
 }


### PR DESCRIPTION
- sidebar navnow is static, so stays in place while just content scrolls
- added reset method to knockout "dirty" extender to allow a observable to reset to the last clean value.
 
implements TASK-472