### PR TITLE
Support for loading knockout components via plugins

### DIFF
--- a/config/ui/ci/build.yml
+++ b/config/ui/ci/build.yml
@@ -132,14 +132,14 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.15.1
+        version: 0.16.0
         cwd: src/plugin
         source:
             bower: {}
     -
         name: user-profile
         globalName: kbase-ui-plugin-user-profile
-        version: 1.0.4
+        version: 1.1.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -132,14 +132,14 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.15.1
+        version: 0.16.0
         cwd: src/plugin
         source:
             bower: {}
     -
         name: user-profile
         globalName: kbase-ui-plugin-user-profile
-        version: 1.0.4
+        version: 1.1.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -86,14 +86,14 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.15.1
+        version: 0.16.0
         cwd: src/plugin
         source:
             bower: {}
     -
         name: user-profile
         globalName: kbase-ui-plugin-user-profile
-        version: 1.0.4
+        version: 1.1.0
         cwd: src/plugin
         source:
             bower: {}

--- a/src/client/modules/app/App.js
+++ b/src/client/modules/app/App.js
@@ -267,6 +267,10 @@ define([
                 runtime: api
             });
 
+            appServiceManager.addService('ko-component', {
+                runtime: api
+            });
+
             pluginManager = pluginManagerFactory.make({
                 runtime: api
             });

--- a/src/client/modules/app/services/ko-component.js
+++ b/src/client/modules/app/services/ko-component.js
@@ -1,0 +1,58 @@
+define([
+    'require',
+    'promise'
+], function (
+    require,
+    Promise
+) {
+    'use strict';
+
+    function factory(config) {
+        var runtime = config.runtime;
+        var components = {};
+
+        function start() {
+            return true;
+        }
+
+        function stop() {
+            return true;
+        }
+
+        function pluginHandler(serviceConfig, pluginConfig) {
+            return Promise.try(function () {
+
+                return Promise.all(serviceConfig.map(function (componentConfig) {
+                    // keep a map of loaded components
+                    if (components[componentConfig.name]) {
+                        throw new Error('Component already loaded "' + componentConfig.name);
+                    }
+
+                    // simply require the module to register the component, or components.
+                    // oops, that would break the model...
+
+                    return new Promise(function (resolve, reject) {
+                        var modulePath = [pluginConfig.moduleRoot, componentConfig.module].join('/');
+                        require([modulePath], function (result) {
+                            resolve(result);
+                        }, function (err) {
+                            reject(err);
+                        });
+                    });
+                }));
+            });
+        }
+        return {
+            // lifecycle interface
+            start: start,
+            stop: stop,
+            // plugin interface
+            pluginHandler: pluginHandler
+        };
+    }
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});


### PR DESCRIPTION
- if a duplicate component is loaded, the app will error
- updated auth2 client and user profile client take advantage of this
- required different plugins to share components (easily).

supports TASK-472 and TASK-758