### PR TITLE
Updated auth2 client and user profile

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
         "jquery": "2.2.4",
         "jquery-ui": "1.12.1",
         "kbase-common-ts": "0.14.1",
-        "kbase-common-js": "2.8.1",
+        "kbase-common-js": "2.8.2",
         "kbase-sdk-clients-js": "0.5.1",
         "kbase-service-clients-js": "3.3.5",
         "kbase-ui-widget": "1.2.0",

--- a/config/ui/ci/build.yml
+++ b/config/ui/ci/build.yml
@@ -132,14 +132,14 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.16.2
+        version: 0.16.3
         cwd: src/plugin
         source:
             bower: {}
     -
         name: user-profile
         globalName: kbase-ui-plugin-user-profile
-        version: 1.1.2
+        version: 1.2.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -132,14 +132,14 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.16.2
+        version: 0.16.3
         cwd: src/plugin
         source:
             bower: {}
     -
         name: user-profile
         globalName: kbase-ui-plugin-user-profile
-        version: 1.1.2
+        version: 1.2.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -86,14 +86,14 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.16.2
+        version: 0.16.3
         cwd: src/plugin
         source:
             bower: {}
     -
         name: user-profile
         globalName: kbase-ui-plugin-user-profile
-        version: 1.1.2
+        version: 1.2.0
         cwd: src/plugin
         source:
             bower: {}

--- a/src/client/require-config.js
+++ b/src/client/require-config.js
@@ -82,7 +82,10 @@ window.require = {
         },
         highlight: {
             deps: ['css!highlight_css']
-        }
+        },
+        'knockout-plus': {
+            deps: ['knockout']
+        },
         // Activate this if using js-yaml with a need for these modules.
         // At the moment, requirejs global handler catches errors loading
         // this within js-yaml and allows js-yaml to detect that they are


### PR DESCRIPTION
auth2 client update brings:
-subdue colors in header for profile editor
-rename "mysteryman" to "silhouette" for anonymous non-gravatar avatar

user profile update brings:
- narrative widget converted from nunjucks-template + datatable to plain js + knockout
- fix regression bugs
- remove narrative editor support

in support ot TASK-758