### PR TITLE
Updated launch date in auth2 client 

### DIFF
--- a/config/deploy/dev-auth2.yml
+++ b/config/deploy/dev-auth2.yml
@@ -20,3 +20,5 @@ services:
   auth2:
     # note that this overrides the auth2 url.
     url: https://authdev.kbase.us/services/auth
+  user_profile:
+    url: https://authdev.kbase.us/services/user_profile/rpc

--- a/config/ui/ci/build.yml
+++ b/config/ui/ci/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.17.0
+        version: 0.17.1
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.17.0
+        version: 0.17.1
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -86,7 +86,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 0.17.0
+        version: 0.17.1
         cwd: src/plugin
         source:
             bower: {}


### PR DESCRIPTION
The launch date appears in several places in the auth2 client, the date has been updated in the auth2 client config which fans out into the content.
Also added local user_profile config for local dev 
in support of TASK-472 and TASK-469