### PR TITLE
auth2 support for token export/import between web apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ nbproject
 /dev/test-coverage
 /install/temp
 /errorShots
+/target
 
 # Editor and OS artifacts
 .DS_Store

--- a/config/deploy/cialt.yml
+++ b/config/deploy/cialt.yml
@@ -1,0 +1,19 @@
+# Deploy-Time Config for Auth2 Local Development
+---
+deploy:
+  environment: cialt
+  hostname: cialt.kbase.us
+  icon: flask
+  name: Continuous Integration Alternative Host
+  services:
+    urlBase: https://cialt.kbase.us
+ui:
+  services:
+    analytics:
+      google:
+        hostname: cialt.kbase.us
+        code: UA-74532036-1
+  features:
+    auth:
+      selected: auth2
+

--- a/config/ui/ci/build.yml
+++ b/config/ui/ci/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.1.0
+        version: 1.1.1
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/ci/build.yml
+++ b/config/ui/ci/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.0.7
+        version: 1.1.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/ci/build.yml
+++ b/config/ui/ci/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.1.1
+        version: 1.1.2
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.1.0
+        version: 1.1.1
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.0.7
+        version: 1.1.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.1.1
+        version: 1.1.2
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -88,7 +88,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.1.0
+        version: 1.1.1
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -88,7 +88,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.0.7
+        version: 1.1.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -88,7 +88,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.1.1
+        version: 1.1.2
         cwd: src/plugin
         source:
             bower: {}

--- a/src/client/modules/plugins/mainwindow/mainwindow
+++ b/src/client/modules/plugins/mainwindow/mainwindow
@@ -1,1 +1,0 @@
-/vagrant/kbase-ui/dev/test/../../../kbase-ui/src/client/modules/plugins/mainwindow


### PR DESCRIPTION
- implemented in auth2-client
- added additional deployment, cialt, an alternative CI deployment for local testing as an alternative proxied ci web app, similar to how appdev is set up.
- currently configured to run against ci/cialt and prod/appdev, hard coded in the modules.
- this can be configurable, but the focus for today is on getting it out expediently; the configuration may move into a separate configuration file