### PR TITLE
Work around for config.json in deployment

### DIFF
--- a/src/search/src/kbaseSession.js
+++ b/src/search/src/kbaseSession.js
@@ -70,11 +70,17 @@ define([
                 // so we just read our cookie
 
                 if (sessionCookie) {
-                    var baseUrl = Config.getConfig('auth_service_base_url');
+                    // TODO: get this working. It requires changes to the deploy script, which is not in this repo.
+                    var authBaseUrl;
+                    if (window.location.host === 'narrative.kbase.us') {
+                        authBaseUrl = window.location.protocol + '//' + 'kbase.us' + '/services/auth';
+                    } else {
+                        authBaseUrl = window.location.protocol + '//' + window.location.host + '/services/auth';
+                    }
                     var session = new Auth2Session.Auth2Session({
                         cookieName: 'kbase_session',
                         // NB: use the configured host not the window hostname.
-                        baseUrl: baseUrl,
+                        baseUrl: authBaseUrl,
                         providers: []
                     });
                     var fakeSession = {

--- a/src/search/src/widgets/kbaseLoginFuncSite.js
+++ b/src/search/src/widgets/kbaseLoginFuncSite.js
@@ -213,10 +213,15 @@
         fetchUserProfile: function () {
             require(['kb.user_profile', 'kb.config', 'kb.session', 'kb.appstate', 'postal', 'kb_common_ts/Auth2Session'],
                 function (UserProfile, Config, Session, AppState, Postal, Auth2Session) {
-                    var baseUrl = Config.getConfig('auth_service_base_url');
+                    var authBaseUrl;
+                    if (window.location.host === 'narrative.kbase.us') {
+                        authBaseUrl = window.location.protocol + '//' + 'kbase.us' + '/services/auth';
+                    } else {
+                        authBaseUrl = window.location.protocol + '//' + window.location.host + '/services/auth';
+                    }
                     var session = new Auth2Session.Auth2Session({
                         cookieName: 'kbase_session',
-                        baseUrl: baseUrl,
+                        baseUrl: authBaseUrl,
                         providers: []
                     });
 


### PR DESCRIPTION
- the config.json is not used directly in deployment, rather an old version is used and manipulated per deployment environment
- rather than ask for changes to that (for now), just making changes directly to the two source locations that need to auth url.