### PR TITLE
Updated RESKE search, reduced connections to fetch modules

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -56,7 +56,7 @@
         "requirejs-domready": "2.0.1",
         "requirejs-json": "0.0.3",
         "requirejs-text": "2.0.15",
-        "requirejs": "eapearson/requirejs#3.0.0-alpha2",
+        "requirejs": "eapearson/requirejs#3.0.0-alpha4",
         "spark-md5": "3.0.0",
         "underscore": "1.8.3",
         "js-yaml": "3.8.3"
@@ -68,7 +68,7 @@
         "nunjucks": "3.0.0",
         "kbase-common-js": "^2.5.0",
         "kbase-service-clients-js": "^3.0.0",
-        "requirejs": "3.0.0-alpha2"
+        "requirejs": "3.0.0-alpha4"
     },
     "devDependencies": {},
     "license": "SEE LICENSE IN LICENSE"

--- a/bower.json
+++ b/bower.json
@@ -56,7 +56,7 @@
         "requirejs-domready": "2.0.1",
         "requirejs-json": "0.0.3",
         "requirejs-text": "2.0.15",
-        "requirejs": "2.3.3",
+        "requirejs": "eapearson/requirejs#3.0.0-alpha2",
         "spark-md5": "3.0.0",
         "underscore": "1.8.3",
         "js-yaml": "3.8.3"
@@ -67,7 +67,8 @@
         "numeral": "2.0.6",
         "nunjucks": "3.0.0",
         "kbase-common-js": "^2.5.0",
-        "kbase-service-clients-js": "^3.0.0"
+        "kbase-service-clients-js": "^3.0.0",
+        "requirejs": "3.0.0-alpha2"
     },
     "devDependencies": {},
     "license": "SEE LICENSE IN LICENSE"

--- a/config/builds/appdev.yml
+++ b/config/builds/appdev.yml
@@ -6,6 +6,7 @@ targets:
 build:
     dist: true
     temp: temp
+vfs: true
 bower:
     offline: false
 debug: false

--- a/config/builds/build.yml
+++ b/config/builds/build.yml
@@ -6,6 +6,7 @@ targets:
 build:
     dist: false
     temp: ../temp
+vfs: false
 bower:
     offline: false
 debug: false

--- a/config/builds/ci.yml
+++ b/config/builds/ci.yml
@@ -6,6 +6,7 @@ targets:
 build:
     dist: true
     temp: temp
+vfs: true
 bower:
     offline: false
 debug: false

--- a/config/builds/dev-auth2.yml
+++ b/config/builds/dev-auth2.yml
@@ -6,6 +6,7 @@ targets:
 build:
     dist: false
     temp: ../temp
+vfs: false
 bower:
     offline: false
 debug: false

--- a/config/builds/dev.yml
+++ b/config/builds/dev.yml
@@ -6,6 +6,7 @@ targets:
 build:
     dist: false
     temp: ../temp
+vfs: false
 bower:
     offline: false
 debug: false

--- a/config/builds/local-dev.yml
+++ b/config/builds/local-dev.yml
@@ -6,6 +6,7 @@ targets:
 build:
     dist: false
     temp: ../temp
+vfs: false
 bower:
     offline: false
 debug: false

--- a/config/builds/narrative-dev.yml
+++ b/config/builds/narrative-dev.yml
@@ -6,6 +6,7 @@ targets:
 build:
     dist: true
     temp: ../temp
+vfs: false
 bower:
     offline: false
 debug: false

--- a/config/builds/next.yml
+++ b/config/builds/next.yml
@@ -6,6 +6,7 @@ targets:
 build:
     dist: true
     temp: temp
+vfs: true
 bower:
     offline: false
 debug: false

--- a/config/builds/prod.yml
+++ b/config/builds/prod.yml
@@ -6,6 +6,7 @@ targets:
 build:
     dist: true
     temp: temp
+vfs: true
 bower:
     offline: false
 debug: false

--- a/config/ui/ci/build.yml
+++ b/config/ui/ci/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.1.11
+        version: 1.1.13
         cwd: src/plugin
         source:
             bower: {}
@@ -167,7 +167,7 @@ plugins:
     -
         name: reske-search
         globalName: kbase-ui-plugin-reske-search
-        version: 0.4.0
+        version: 0.5.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/dev/build.yml
+++ b/config/ui/dev/build.yml
@@ -132,7 +132,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.1.11
+        version: 1.1.13
         cwd: src/plugin
         source:
             bower: {}
@@ -167,7 +167,7 @@ plugins:
     -
         name: reske-search
         globalName: kbase-ui-plugin-reske-search
-        version: 0.4.0
+        version: 0.5.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/ui/prod/build.yml
+++ b/config/ui/prod/build.yml
@@ -88,7 +88,7 @@ plugins:
         name: auth2-client
         disabled: true
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.1.11
+        version: 1.1.13
         cwd: src/plugin
         source:
             bower: {}

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -32,13 +32,15 @@
             If you have additional questions or concerns please <a href="http://kbase.us/contact">contact us</a>.
         </p>
     </noscript>
-    <script src="/fallback.js?cb={{git.commitAbbreviatedHash}}"></script>
-    <script src="/mustard.js?cb={{git.commitAbbreviatedHash}}"></script>
-    <script src="/modules/bower_components/bluebird/bluebird.js?cb={{git.commitAbbreviatedHash}}"></script>
-    <script src="/build-info.js?cb={{git.commitAbbreviatedHash}}"></script>
-    <script src="/moduleVfs.js?cb={{git.commitAbbreviatedHash}}"></script>
-    <script src="/require-config.js?cb={{git.commitAbbreviatedHash}}"></script>
-    <script src="/modules/bower_components/requirejs/require.js?cb={{git.commitAbbreviatedHash}}" data-main="startup"></script>
+    <script src="/fallback.js?cb={{buildInfo.git.commitAbbreviatedHash}}"></script>
+    <script src="/mustard.js?cb={{buildInfo.git.commitAbbreviatedHash}}"></script>
+    <!--<script src="/modules/bower_components/bluebird/bluebird.js?cb={{git.commitAbbreviatedHash}}"></script>-->
+    <script src="/build-info.js?cb={{buildInfo.git.commitAbbreviatedHash}}"></script>
+    {{#if config.vfs}}
+    <script src="/moduleVfs.js?cb={{buildInfo.git.commitAbbreviatedHash}}"></script>
+    {{/if}}
+    <script src="/require-config.js?cb={{buildInfo.git.commitAbbreviatedHash}}"></script>
+    <script src="/modules/bower_components/requirejs/require.js?cb={{buildInfo.git.commitAbbreviatedHash}}" data-main="startup"></script>
 </body>
 
 </html>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -36,7 +36,7 @@
     <script src="/mustard.js?cb={{git.commitAbbreviatedHash}}"></script>
     <script src="/modules/bower_components/bluebird/bluebird.js?cb={{git.commitAbbreviatedHash}}"></script>
     <script src="/build-info.js?cb={{git.commitAbbreviatedHash}}"></script>
-    <!-- <script src="/moduleVfs.js"></script> -->
+    <script src="/moduleVfs.js?cb={{git.commitAbbreviatedHash}}"></script>
     <script src="/require-config.js?cb={{git.commitAbbreviatedHash}}"></script>
     <script src="/modules/bower_components/requirejs/require.js?cb={{git.commitAbbreviatedHash}}" data-main="startup"></script>
 </body>

--- a/src/client/load-narrative.html
+++ b/src/client/load-narrative.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <title>KBase Narrative Interface</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <script src="/build-info.js?cb={{git.abbreviatedSha}}"></script>
-    <script src="/require-config.js?cb={{git.abbreviatedSha}}"></script>
-    <script src="/modules/bower_components/requirejs/require.js?cb={{git.abbreviatedSha}}"></script>
+    <script src="/build-info.js?cb={{buildInfo.git.abbreviatedSha}}"></script>
+    <script src="/require-config.js?cb={{buildInfo.git.abbreviatedSha}}"></script>
+    <script src="/modules/bower_components/requirejs/require.js?cb={{buildInfo.git.abbreviatedSha}}"></script>
     <style type="text/css">
         .remove-me-to-show-me {
             display: none;

--- a/src/client/loading.html
+++ b/src/client/loading.html
@@ -4,9 +4,9 @@
 <head>
     <title>KBase Narrative Interface</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <script src="/build-info.js?cb={{git.abbreviatedSha}}"></script>
-    <script src="/require-config.js?cb={{git.abbreviatedSha}}"></script>
-    <script src="/modules/bower_components/requirejs/require.js?cb={{git.abbreviatedSha}}"></script>
+    <script src="/build-info.js?cb={{buildInfo.git.abbreviatedSha}}"></script>
+    <script src="/require-config.js?cb={{buildInfo.git.abbreviatedSha}}"></script>
+    <script src="/modules/bower_components/requirejs/require.js?cb={{buildInfo.git.abbreviatedSha}}"></script>
 </head>
 
 <body>

--- a/src/client/modules/plugins/mainwindow/modules/bodyWidget.js
+++ b/src/client/modules/plugins/mainwindow/modules/bodyWidget.js
@@ -41,7 +41,7 @@ define([
                         })
                         .catch(function (err) {
                             // need a catch-all widget to mount here??
-                            console.error('ERROR mounting widget');
+                            console.error('ERROR mounting widget', data);
                             console.error(err);
                             widgetMount.unmount()
                                 .then(function () {


### PR DESCRIPTION
- RESKE search support adds first pass at listing / browsing for genomes
- Incorporation of the module virtual file system with a build switch to enable for production builds.
- This greatly reduces the number of network connections to fetch modules (js, css, json, yaml), at the cost of a somewhat large initial fetch (2.5M compressed). This should be considered experimental, and can be easily turned off.