### PR TITLE
Initial checkin of working kbase-ui docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:latest
+RUN apk add --no-cache 
+# Container designed to serve up static KBase UI contents
+
+# These ARGs values are passed in via the docker build command
+ARG BUILD_DATE
+ARG VCS_REF
+ARG BRANCH=develop
+
+# Shinto-cli is a jinja2 template cmd line tool
+# Install perl dependencies. Force Moose and RPC::Any::Server::JSONRPC::PSGI installation
+# as the perl interpreter updates have broken the library unit tests
+RUN apk --update upgrade && \
+    apk add ca-certificates nginx python py-pip openssl wget bash bash-completion && \
+    update-ca-certificates && \
+    pip install shinto-cli[yaml]
+
+# Setup the base perl libs
+RUN mkdir -p /kb/deployment/lib
+
+COPY deployment /kb/deployment
+
+# The BUILD_DATE value seem to bust the docker cache when the timestamp changes, move to
+# the end
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/kbase/kbase-ui.git" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.schema-version="1.0.0-rc1" \
+      us.kbase.vcs-branch=$BRANCH  \
+      maintainer="Steve Chan sychan@lbl.gov"
+
+EXPOSE 80
+ENTRYPOINT [ "/kb/deployment/bin/entrypoint.sh" ]

--- a/build/build_docker_image.sh
+++ b/build/build_docker_image.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+export BRANCH=${TRAVIS_BRANCH:-`git symbolic-ref --short HEAD`}
+export DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+export COMMIT=${TRAVIS_COMMIT:-`git rev-parse --short HEAD`}
+docker build --build-arg BUILD_DATE=$DATE \
+     		 --build-arg VCS_REF=$COMMIT \
+			 --build-arg BRANCH=$BRANCH \
+             -t kbase/kbase_ui:$COMMIT .

--- a/build/push2dockerhub.sh
+++ b/build/push2dockerhub.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# 
+# This script is intended to be run in the deploy stage of a travis build
+# It checks to make sure that this is a not a PR, and that we have the secure
+# environment variables available and then checks if this is either the master
+# or develop branch, otherwise we don't push anything
+#
+# NOTE: IMAGE_NAME is expected to be passed in via the environment so that this
+# script can be more general
+#
+# sychan@lbl.gov
+# 8/31/2017
+
+# Assign the tag to be used for the docker image, and pull the git commit from either
+# the TRAVIS_COMMIT env var if available, or else get the short commit via git cmd
+TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
+COMMIT=${TRAVIS_COMMIT:-`git rev-parse --short HEAD`}
+
+if ( [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] ); then
+    # $TAG was set from TRAVIS_BRANCH, which is a little wonky on pull requests,
+    # but it should be okay since we should never get here on a PR
+    if  ( [ "$TAG" == "latest" ] || [ "$TAG" == "develop" ] ) ; then
+        echo "Logging into Dockerhub as $DOCKER_USER"
+        docker login -u $DOCKER_USER -p $DOCKER_PASS && \
+        docker tag $IMAGE_NAME:$COMMIT $IMAGE_NAME:$TAG && \
+        echo "Pushing $IMAGE_NAME:$TAG" && \
+        docker push $IMAGE_NAME:$TAG || \
+        ( echo "Failed to login and push tagged image" && exit 1 )
+    else
+        echo "Not pushing image for branch $TAG"
+    fi
+else
+    echo "Not building image for pull requests or if secure variables unavailable"
+fi

--- a/deployment/bin/README
+++ b/deployment/bin/README
@@ -1,0 +1,1 @@
+This directory is intended to hold support scripts/binaries

--- a/deployment/bin/entrypoint.sh
+++ b/deployment/bin/entrypoint.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# This script is used as the entrypoint for the docker image
+# 
+# This entrypoint script defaults to using environment variables to populate
+# a jinja2 config template and writing out the config before starting the service
+#
+# If a first parameter is given it overrides the environment variables for the
+# data source and is either a file path or a URL
+# If a second parameter is given it overrides the default template and it should be
+# either a file path or a URL
+#
+# If there is a readable file at /run/secrets/auth_data then it will be read in
+# and passed as a header for a request to the data source URL, it must be in the
+# form "HEADER_NAME:VALUE" that httpie uses for custom headers. For example, to
+# set a gitlab private token header you would create a file that contains
+# "PRIVATE-TOKEN:mesoextrasecret"
+# A readable file at /run/secrets/auth_template is used for custom headers to the
+# template URL. Note that they are separated to avoid leaking creds to a URL that
+# doesn't require them
+#
+
+# Define an error exit function
+function error_exit
+{
+	echo "$1" 1>&2
+	exit 1
+}
+
+# This is the path to the jinja2 template tool, some derivative of
+# this: https://github.com/kolypto/j2cli
+export J2=/usr/bin/j2
+
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+# Default config template
+TEMPLATE=$DIR/../conf/.templates/nginx.conf.j2
+
+# This is the path to the nginx config created by template above
+NGINX_CONFIG=/etc/nginx/nginx.conf
+
+# Config.json template, uses the same data source
+CFG_JSON_TEMPLATE=$DIR/../conf/.templates/config.json.j2
+
+# Destination for the config.json template above
+CONFIG_JSON=$DIR/../services/kbase-ui/modules/deploy/config.json
+
+# Verify that the directory that the config.json goes into exists, otherwise
+# create it
+CFG_DIR="$(dirname $CONFIG_JSON)"
+if [ ! -d $CFG_DIR ]; then
+    mkdir -p $CFG_DIR
+fi
+
+# Default data source is empty, resulting in env variables being used
+DATA_SRC=""
+
+# Set empty default values for the auth headers
+AUTH_DATA=""
+AUTH_TEMPLATE=""
+
+# Auth header secret paths - can be declared in docker-compose secrets declaration
+if [ -r "/run/secrets/auth_data" ]; then
+     AUTH_DATA=`cat /run/secrets/auth_data`
+fi
+if [ -r "/run/secrets/auth_template" ]; then
+    AUTH_TEMPLATE=`cat /run/secrets/auth_template`
+fi
+
+# If we have a first argument see if it is a file else treat a URL, this
+# is the dictionary context for the jinja2 template config file
+if [ "$1" ] ; then
+    if [ -r $1 ] ; then
+        DATA_SRC=$1
+    else
+        TMPDIR=/tmp/data$$
+        mkdir $TMPDIR
+        # Fetch the file, and have it error out on any redirects to avoid a 200 response
+        # that is just a redirect to a login screen. Ignore cert signing issues for when
+        # we connect to an internal server with self-signed certs.
+        wget -q -nd --max-redirect=0 --no-check-certificate --header="${AUTH_DATA}" -P $TMPDIR -N $1  || \
+            error_exit "Error fetching $1"
+        # Use a file glob to pickup whatever the file name ended up being (to avoid parsing URL for name)
+        DATA_SRC=$TMPDIR/*
+    fi
+fi
+
+# If we are given a second parameter treat it as a template file path or
+# a URL
+if [ "$2" ] ; then
+    if [ -r $2 ]; then
+        TEMPLATE=$2
+    else
+        # Create a temp directory for downloading the file so that it is the only
+        # file there
+        TMPDIR2=/tmp/template$$
+        mkdir $TMPDIR2
+        pushd $TMPDIR2
+        # Ignore certs signing issues for when we connect to an internal server with self-signed certs.
+        wget -q -nd --max-redirect=0 --no-check-certificate --header="${AUTH_TEMPLATE}" -P $TMPDIR2 -N $2 || \
+            error_exit "Error fetching $2"
+        popd
+        TEMPLATE=$TMPDIR2/*
+    fi
+fi
+
+# Populate the nginx config as well as the config.json
+${J2} $TEMPLATE $DATA_SRC > $NGINX_CONFIG && \
+${J2} $CFG_JSON_TEMPLATE $DATA_SRC > $CONFIG_JSON && \
+nginx

--- a/deployment/conf/.templates/config.json.j2
+++ b/deployment/conf/.templates/config.json.j2
@@ -1,0 +1,41 @@
+{
+    "deploy": {
+        "environment": "{{ deploy_environment|default("ci")}}",
+        "hostname": "{{ deploy_hostname|default("ci.kbase.us")}}",
+        "icon": "thumbs-up",
+        "name": "{{ deploy_name|default("Continuous Integration")}}",
+        "services": {
+            "urlBase": "{{ deploy_services_urlBase|default("ci.kbase.us")}}"
+        }
+    },
+    "ui": {
+        "backupCookie": {
+            "domain": "{{ ui_backupCookie_domain|default("ci.kbase.us")}}",
+            "enabled": {{ ui_backupCookie_enabled|default("true")}}
+        },
+        "services": {
+            "analytics": {
+                "google": {
+                    "hostname": "{{ ui_services_analytics_google_hostname|default("kbase.us")}}",
+                    "code": "{{ ui_services_analytics_google_code|default("UA-74532036-1")}}"
+                }
+            }
+        },
+{%- if (deploy_environment is not defined) or (deploy_environment in ['ci', 'appdev']) %}
+        "allow": [
+            "alpha",
+            "beta"
+        ]
+{%- endif %}
+        "features": {
+            "auth": {
+                "selected": "auth2"
+            }
+        }
+    },
+    "services": {
+        "narrative": {
+            "url": "{{ services_narrative|default("https://ci.kbase.us/") }}
+        }
+    }
+}

--- a/deployment/conf/.templates/nginx.conf.j2
+++ b/deployment/conf/.templates/nginx.conf.j2
@@ -1,0 +1,45 @@
+daemon off;
+error_log /dev/stdout info;
+worker_processes auto;
+pid /var/run/nginx.pid;
+
+events {
+	worker_connections 256;
+	# multi_accept on;
+}
+
+
+http {
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+    error_log /dev/stdout;
+	access_log syslog:server=10.58.0.54,facility=local2,tag=ci,severity=info combined;
+
+    server {
+        # no need for root privileges
+        listen      80;
+        server_name {{ nginx_server_name|default("localhost") }};
+        
+        location / {
+			index index.html;
+			ssi_silent_errors off;
+			allow all;
+
+            # insert desired path here
+            root /kb/deployment/services/kbase-ui/;
+        }
+    }
+}

--- a/deployment/conf/README
+++ b/deployment/conf/README
@@ -1,0 +1,1 @@
+This is a placeholder for deployment configuration files


### PR DESCRIPTION
Hi Erik,
   This setup  works for me - you can find the jinja2 templated config in deployment/conf/.templates. This is a consequent of the fact the the actual config files for services end up in deployment/conf, so I put the templates in a hidden directory underneath.

   The deployment/bin/entrypoint.sh is what is run on container startup and if you give it a URL or a file path it will use that as the source for the context in which to render the template.
   The build/build_docker_image.sh script actually builds and tags the docker image. This script normally gets call from a travis.yml or makefile, but I'm leaving that layer out for now.
    You already had a build directory, but it seemed to be unused for quite some time, and I've kind of settled on using a /build directory for build scripts, hopefully that won't upset any plans.