### PR TITLE
New admin stats interface

### DIFF
--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
@@ -14,15 +14,13 @@ define([
         'kb_service/client/narrativeJobService',
         '../catalog_util',
         'kb_common/dynamicTable',
-        //'kb_sdk_clients/genericClient',
-        'kb_common/jsonRpc/genericClient',
         'kb_common/jsonRpc/dynamicServiceClient',
         'datatables',
         'kb_widget/legacy/authenticatedWidget',
         'bootstrap',
         'datatables_bootstrap',
     ],
-    function ($, Promise, NarrativeMethodStore, Catalog, NarrativeJobService, CatalogUtil, DynamicTable, GenericClient, DynamicService) {
+    function ($, Promise, NarrativeMethodStore, Catalog, NarrativeJobService, CatalogUtil, DynamicTable, DynamicService) {
 
         function renderDate ( date, type, full ) {
           if(type == "display"){

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
@@ -87,6 +87,9 @@ define([
                   version : 'dev',
                   module : 'kb_Metrics',
                 });
+
+                self.adminRecentRuns = [];
+
                 return this;
             },
 
@@ -150,6 +153,7 @@ define([
 
             // this just takes the rows that come back from the various stats methods and reformats them into the arrays of arrays that dynamicTable likes.
             restructureRows : function(config, rows) {
+              if (!rows) { return [] }
               return rows.map( function(row) {
                 var rowArray = [];
                 config.headers.forEach( function (header) {
@@ -736,10 +740,11 @@ define([
                 var now  = self.nowDate  || (new Date()).getTime();
                 var then = self.thenDate || now - self.numHours * 60 * 60 * 1000;
 
+                self.adminRecentRuns = [];
+
                 return self.metricsClient.callFunc('get_app_metrics', [{epoch_range : [then, now]}]).then(function(data) {
                   var jobs = data[0].job_states;
 
-                  self.adminRecentRuns = [];
                   jobs.forEach( function( job, idx ) {
 
 

--- a/src/client/modules/plugins/catalog/resources/css/catalog_styles.css
+++ b/src/client/modules/plugins/catalog/resources/css/catalog_styles.css
@@ -283,8 +283,8 @@
 }
 
 .kbcb-active-filter {
-  border : 1px solid blue;
-  background-color : #EEEEFF;
-  border-radius : 5px;
-  padding : 6px 12px 12px 6px;
+  border            : 1px solid blue;
+  background-color  : #EEEEFF;
+  border-radius     : 5px;
+  padding           : 6px 12px 12px 6px;
 }

--- a/src/client/modules/plugins/catalog/resources/css/catalog_styles.css
+++ b/src/client/modules/plugins/catalog/resources/css/catalog_styles.css
@@ -281,3 +281,10 @@
 .kbcb-reg-main-panel {
     margin: 0.2em 2.0em 0.2em 2.0em;
 }
+
+.kbcb-active-filter {
+  border : 1px solid blue;
+  background-color : #EEEEFF;
+  border-radius : 5px;
+  padding : 6px 12px 12px 6px;
+}


### PR DESCRIPTION
Large scale re-write of this widget -
* the admin stats now use get_app_metrics and can filter based on a few flags, as well as change the date range (though it could use a date pop up picker)
* data tables was yanked out in favor of dynamicTable, though I feel like I'm using it wrong.

The changes are documented and mostly reasonable, but I feel like it's got too much indirection and fighting against the dynamicTable widget. But, it all does appear to work.

If possible, it'd be awesome to get this approved so we can bump it up to CI before the demos, but still note any review modifications so I can come back to 'em and tidy things up as possible at a later date.