### PR TITLE
Tidying up code on catalog page

### DIFF
--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
@@ -749,7 +749,7 @@ define([
 
                 return self.metricsClient.callFunc('get_app_metrics', [{epoch_range : [then, now]}]).then(function(data) {
                   var jobs = data[0].job_states;
-console.log("GOT JOBS : ", jobs);
+
                   jobs.forEach( function( job, idx ) {
 
 

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
@@ -811,7 +811,7 @@ define([
 
             checkIsAdmin: function () {
                 var self = this;
-                self.isAdmin = true;
+                self.isAdmin = false;
 
                 var me = self.runtime.service('session').getUsername();
                 return self.catalog.is_admin(me)

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
@@ -684,7 +684,7 @@ define([
 
             getAdminUserStats: function () {
                 var self = this;
-                if (self.isAdmin) {
+                if (!self.isAdmin) {
                     return Promise.try(function () {});
                 }
 

--- a/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
+++ b/src/client/modules/plugins/catalog/modules/widgets/kbaseCatalogStats.js
@@ -684,7 +684,7 @@ define([
 
             getAdminUserStats: function () {
                 var self = this;
-                if (1) {
+                if (self.isAdmin) {
                     return Promise.try(function () {});
                 }
 


### PR DESCRIPTION
A couple of minor bugs were spotted after merging. Nothing critical to put in before the demo, but reasonable to do so if you're so inclined.

* There was potential for a race condition with the metricsClient, since it was actually created after the promises which may use it were invoked. Moved it down into the setupClients method.
* reformatIntervalInTD would spit out "NaNs" if a job was still running, now it spits out '...', same as reformatDateInTD
* The status will now say "Running" in yellow if the job is running, instead of claiming it was a success.