### PR TITLE
jig-search and reske-simple-search improvements

### DIFF
--- a/config/app/ci/plugins.yml
+++ b/config/app/ci/plugins.yml
@@ -167,7 +167,7 @@ plugins:
     -
         name: jgi-search
         globalName: kbase-ui-plugin-jgi-search
-        version: 0.28.1
+        version: 0.28.3
         cwd: src/plugin
         source:
             bower: {}
@@ -195,7 +195,7 @@ plugins:
     -
         name: reske-simple-search
         globalName: kbase-ui-plugin-reske-simple-search
-        version: 0.5.0
+        version: 0.5.1
         cwd: src/plugin
         source:
             bower: {}            

--- a/config/app/dev/plugins.yml
+++ b/config/app/dev/plugins.yml
@@ -167,7 +167,7 @@ plugins:
     -
         name: jgi-search
         globalName: kbase-ui-plugin-jgi-search
-        version: 0.28.1
+        version: 0.28.3
         cwd: src/plugin
         source:
             bower: {}
@@ -202,7 +202,7 @@ plugins:
     -
         name: reske-simple-search
         globalName: kbase-ui-plugin-reske-simple-search
-        version: 0.5.0
+        version: 0.5.1
         cwd: src/plugin
         source:
             bower: {}

--- a/src/client/modules/lib/knockout-plus.js
+++ b/src/client/modules/lib/knockout-plus.js
@@ -3,6 +3,7 @@ define([
     'moment',
     'knockout',
     'kb_common/utils',
+    'kb_common/html',
     'knockout-mapping',
     'knockout-arraytransforms',
     'knockout-validation',
@@ -11,7 +12,8 @@ define([
     numeral,
     moment,
     ko,
-    Utils
+    Utils,
+    html
 ) {
     // Knockout Defaults
     ko.options.deferUpdates = true;
@@ -431,6 +433,65 @@ define([
         }, callbackTarget, event); 
         return sourceObservable; 
     };
+
+    // pure functions stuck onto ko
+
+    var t = html.tag,
+        div = t('div');
+
+    function komponent(componentDef) {
+        return '<!-- ko component: {name: "' + componentDef.name +
+            '", params: {' +
+            Object.keys(componentDef.params).map(function (key) {
+                return key + ':' + componentDef.params[key];
+            }).join(',') + '}}--><!-- /ko -->';
+    }
+
+    function createRootComponent(runtime, name) {
+        var vm = {
+            runtime: runtime,
+            running: ko.observable(false)
+        };
+        var temp = document.createElement('div');
+        temp.innerHTML = div({
+            style: {
+                flex: '1 1 0px',
+                display: 'flex',
+                flexDirection: 'column'
+            }
+        }, [
+            '<!-- ko if: running -->',
+            komponent({
+                name: name,
+                params: {
+                    runtime: 'runtime'
+                }
+            }),
+            '<!-- /ko -->'
+        ]);
+        var node = temp.firstChild;
+        ko.applyBindings(vm, node);
+
+        function start() {
+            vm.running(true);
+        }
+
+        function stop() {
+            vm.running(false);
+        }
+       
+        return {
+            vm: vm,
+            node: node,
+            start: start,
+            stop: stop
+        };
+    }
+
+    ko.kb = {};
+
+    ko.kb.komponent = komponent;
+    ko.kb.createRootComponent = createRootComponent;
 
     return ko;
 });


### PR DESCRIPTION
- focused on improving loading and unloading of main component
- moved komponent helper to knockout plus 
- add createRootComponent which captures the boilerplate of creating a top level component which integrates nicely into a plugin panel widget.