### PR TITLE
rewires catalog widget [SCT-279]

### DIFF
--- a/src/search/js/require-config.js
+++ b/src/search/js/require-config.js
@@ -91,7 +91,6 @@ require.config({
         'kb.widget.dashboard.data': 'src/widgets/dashboard/DataWidget',
         'kb.widget.dashboard.collaborators': 'src/widgets/dashboard/CollaboratorsWidget',
         'kb.widget.dashboard.metrics': 'src/widgets/dashboard/MetricsWidget',
-        'kb.widget.dashboard.jobs': 'src/widgets/dashboard/JobsWidget',
 
         // Dataview widgets
         'kb.widget.dataview.base': 'src/widgets/dataview/DataviewWidget',

--- a/src/search/js/require-config.js
+++ b/src/search/js/require-config.js
@@ -91,6 +91,7 @@ require.config({
         'kb.widget.dashboard.data': 'src/widgets/dashboard/DataWidget',
         'kb.widget.dashboard.collaborators': 'src/widgets/dashboard/CollaboratorsWidget',
         'kb.widget.dashboard.metrics': 'src/widgets/dashboard/MetricsWidget',
+        'kb.widget.dashboard.jobs': 'src/widgets/dashboard/JobsWidget',
 
         // Dataview widgets
         'kb.widget.dataview.base': 'src/widgets/dataview/DataviewWidget',


### PR DESCRIPTION
This retools the kbaseCatalogStats widget so it can be dropped into the user panel. An argument could be made about whether that should be a completely separate widget, but I opted for DRY.

There's a little bit of technical debt here in that the way the config is set up and the fields are re-formatted is brittle, but I'll circle back to it. Hoping to get it in by the demo.

NOTE - the isAdmin flag isn't used atm. It's not relevant at all for get_app_metrics, since who cares if you're a catalog service admin calling a metrics service method. This'll now cause a user to attempt to load a recentRunsSummary table (which'll fail due to permissions). We should circle back to a better definition of an admin.