### PR TITLE
fixes jgi search terms agreement, removes job browser from hamburger

### DIFF
--- a/config/app/ci/menus.yml
+++ b/config/app/ci/menus.yml
@@ -1,7 +1,7 @@
 menus:
     authenticated:
         main: [narrative, bulk-ui]
-        developer: [jobbrowser, reske-admin, jgi-search, staging-browser]
+        developer: [reske-admin, jgi-search, staging-browser]
         help: [about, about-services, contact-kbase, help]
     unauthenticated:
         main: []

--- a/config/app/ci/plugins.yml
+++ b/config/app/ci/plugins.yml
@@ -169,7 +169,7 @@ plugins:
     -
         name: jgi-search
         globalName: kbase-ui-plugin-jgi-search
-        version: 0.31.0
+        version: 0.31.1
         cwd: src/plugin
         source:
             bower: {}

--- a/config/app/dev/menus.yml
+++ b/config/app/dev/menus.yml
@@ -1,7 +1,7 @@
 menus:
     authenticated:
         main: [narrative, bulk-ui]
-        developer: [simple-sample, staging-browser,  example-gopherjs, reske-admin, reske-object-search,jgi-search, tester, test_dynamic_table, paveldemo, sdkclientstest, databrowser, typebrowser, jobbrowser, shockbrowser]
+        developer: [simple-sample, staging-browser,  example-gopherjs, reske-admin, reske-object-search,jgi-search, tester, test_dynamic_table, paveldemo, sdkclientstest, databrowser, typebrowser,  shockbrowser]
         help: [about, about-services, contact-kbase, help]
         # TODO: congigurable sidebar menu items
         # sidebar: [dashboard, catalog, account, reske-narrative-search]

--- a/config/app/dev/plugins.yml
+++ b/config/app/dev/plugins.yml
@@ -167,7 +167,7 @@ plugins:
     -
         name: jgi-search
         globalName: kbase-ui-plugin-jgi-search
-        version: 0.31.0
+        version: 0.31.1
         cwd: src/plugin
         source:
             bower: {}


### PR DESCRIPTION
- terms agreement had broken in jig-search due to recent refactor (regression)
- job browser is now in sidebar nav, shouldn't be in hamburger