### PR TITLE
jgi search tool no longer uses manual operators [SCT-123]

### DIFF
--- a/config/app/ci/plugins.yml
+++ b/config/app/ci/plugins.yml
@@ -169,7 +169,7 @@ plugins:
     -
         name: jgi-search
         globalName: kbase-ui-plugin-jgi-search
-        version: 0.31.2
+        version: 0.31.3
         cwd: src/plugin
         source:
             bower: {}

--- a/config/app/dev/plugins.yml
+++ b/config/app/dev/plugins.yml
@@ -167,7 +167,7 @@ plugins:
     -
         name: jgi-search
         globalName: kbase-ui-plugin-jgi-search
-        version: 0.31.2
+        version: 0.31.3
         cwd: src/plugin
         source:
             bower: {}


### PR DESCRIPTION
- due to a change in the jgi search backend, the front end no longer needs to interpolate "and" + operators between terms to get the desired behavior
- this opens the path to using full ES simple query search syntax (although we still don't want users to get used to it -- it may get yanked later with the move to SOLR).