### PR TITLE
taxonomy widget fix, other internal improvements

### DIFF
--- a/config/app/dev/plugins.yml
+++ b/config/app/dev/plugins.yml
@@ -33,7 +33,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 3.7.4
+        version: 3.8.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/app/dev/services.yml
+++ b/config/app/dev/services.yml
@@ -13,6 +13,7 @@ ui:
     schema: {}
     route: {}
     session: {}
+    rpc: {}
     # dynamic-service: {}
     menu:
       menus:
@@ -28,6 +29,9 @@ ui:
                   auth: true
             developer:
               items: 
+                # -
+                #   id: ui-service
+                #   auth: true
                 - 
                   id: dashboard2
                   auth: true

--- a/config/app/prod/plugins.yml
+++ b/config/app/prod/plugins.yml
@@ -33,7 +33,7 @@ plugins:
     -
         name: dataview
         globalName: kbase-ui-plugin-dataview
-        version: 3.7.4
+        version: 3.8.0
         cwd: src/plugin
         source:
             bower: {}

--- a/config/app/prod/services.yml
+++ b/config/app/prod/services.yml
@@ -13,6 +13,7 @@ ui:
     schema: {}
     route: {}
     session: {}
+    rpc: {}
     # dynamic-service: {}
     menu:
       menus:

--- a/src/client/modules/app/App.js
+++ b/src/client/modules/app/App.js
@@ -7,21 +7,21 @@
     - provide runtime api for config, services, and comm
 */
 define([
-    '../lib/pluginManager',
+    'lib/pluginManager',
+    'lib/appServiceManager',
     './runtime',
     'kb_common/messenger',
     'kb_common/props',
     'kb_widget/widgetMount',
-    'kb_common/asyncQueue',
-    'kb_common/appServiceManager',
+    'kb_common/asyncQueue'
 ], function (
     pluginManagerFactory,
+    AppServiceManager,
     Runtime,
     messengerFactory,
     Props,
     widgetMountFactory,
-    asyncQueue,
-    AppServiceManager
+    asyncQueue
 ) {
     'use strict';
 

--- a/src/client/modules/app/runtime.js
+++ b/src/client/modules/app/runtime.js
@@ -136,17 +136,6 @@ define([
             getService: function () {
                 return proxyMethod(serviceManager, 'getService', arguments);
             }
-
-            // pretty sure all this is defunct.
-            // addService: function () {
-            //     return proxyMethod(appServiceManager, 'addService', arguments);
-            // },
-            // loadService: function () {
-            //     return proxyMethod(appServiceManager, 'loadService', arguments);
-            // },
-            // dumpServices: function () {
-            //     return proxyMethod(appServiceManager, 'dumpServices', arguments);
-            // }
         });
     }
 

--- a/src/client/modules/app/services/rpc.js
+++ b/src/client/modules/app/services/rpc.js
@@ -1,0 +1,61 @@
+define([
+    'bluebird',
+    'lib/rpc'
+], function (
+    Promise, 
+    rpc
+) {
+    'use strict';
+
+    // function proxyMethod(obj, method, args) {
+    //     if (!obj[method]) {
+    //         throw {
+    //             name: 'UndefinedMethod',
+    //             message: 'The requested method "' + method + '" does not exist on this object',
+    //             suggestion: 'This is a developer problem, not your fault'
+    //         };
+    //     }
+    //     return obj[method].apply(obj, args);
+    // }
+
+    function factory(config) {
+        var runtime = config.runtime;
+
+        function start() {
+            return true;
+        }
+        function stop() {
+            return true;
+        }
+        function pluginHandler(widgetsConfig, pluginConfig) {
+            return Promise.try(function () {
+                // widgetsConfig.forEach(function (widgetDef) {
+                //     // If source modules are not specified, we are using module
+                //     // paths. A full path will start with "plugins/" and a relative
+                //     // path won't. Prefix a relative path with the plugin's module path.
+                //     if (!pluginConfig.usingSourceModules) {
+                //         if (!widgetDef.module.match(/^plugins\//)) {
+                //             widgetDef.module = [pluginConfig.moduleRoot, widgetDef.module].join('/');
+                //         }
+                //     }
+                //     widgetManager.addWidget(widgetDef);
+                // });
+            });
+        }
+
+        function makeClient(arg) {
+            let client = new rpc.RPCClient({
+                runtime: runtime,
+                module: arg.module
+            });
+            return client;
+        }
+
+        return {start, stop, pluginHandler, makeClient};        
+    }
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/src/client/modules/lib/appServiceManager.js
+++ b/src/client/modules/lib/appServiceManager.js
@@ -1,0 +1,120 @@
+define([
+    'bluebird'
+], function (
+    Promise
+) {
+    'use strict';
+
+    function AppServiceError(type, message, suggestion) {
+        this.type = type;
+        this.message = message;
+        this.suggestion = suggestion;
+    }
+    AppServiceError.prototype = Object.create(Error.prototype);
+    AppServiceError.prototype.constructor = AppServiceError;
+    AppServiceError.prototype.name = 'AppServiceError';
+
+    function factory(config) {
+        var services = {};
+        var moduleBasePath = config.moduleBasePath;
+
+        if (!moduleBasePath) {
+            throw new TypeError('moduleBasePath not provided to factory');
+        }
+
+        function addService(serviceConfig, serviceDef) {
+            services[serviceConfig.name] = {
+                name: serviceConfig.name,
+                module: serviceConfig.module,
+                config: serviceDef
+            };
+        }
+
+        function loadService(name) {
+            return new Promise(function (resolve, reject) {
+                var service = services[name],
+                    moduleName = [moduleBasePath, service.module].join('/');
+                require([moduleName], function (serviceFactory) {
+                    var serviceInstance = serviceFactory.make(services[name].config);
+                    services[name].instance = serviceInstance;
+                    resolve();
+                }, function (err) {
+                    reject(err);
+                });
+            });
+        }
+
+        function loadServices() {
+            var all = Object.keys(services).map(function (name) {
+                return loadService(name);
+            });
+            return Promise.all(all);
+        }
+
+        function startServices() {
+            var all = Object.keys(services).map(function (name) {
+                var service = services[name].instance;
+                if (!service) {
+                    console.warn('Warning: no service started for ' + name);
+                    throw new Error('No service started for ' + name);
+                }
+                if (!service.start) {
+                    console.warn('Warning: no start method for ' + name);
+                    return;
+                }
+                return service.start();
+            });
+            return Promise.all(all);
+        }
+
+        function stopServices() {
+            var all = Object.keys(services).map(function (name) {
+                var service = services[name];
+                if (service && service.instance && service.instance.stop) {
+                    return service.instance.stop();
+                }
+            });
+            return Promise.all(all);
+        }
+
+        function hasService(name) {
+            if (!services[name]) {
+                return false;
+            }
+            return true;
+        }
+
+        function getService(name) {
+            var service = services[name];
+            if (!service) {
+                // TODO: throw real exception
+                throw new AppServiceError({
+                    type: 'UndefinedService',
+                    message: 'The requested service "' + name + '" has not been registered',
+                    suggestion: 'This is a system configuration issue. The requested service should be installed or the client code programmed to check for its existence first (with hasService)'
+                });
+            }
+            return service.instance;
+        }
+
+        function dumpServices() {
+            return services;
+        }
+
+        return {
+            addService: addService,
+            getService: getService,
+            loadService: loadService,
+            hasService: hasService,
+            loadServices: loadServices,
+            startServices: startServices,
+            stopServices: stopServices,
+            dumpServices: dumpServices
+        };
+    }
+
+    return {
+        make: factory,
+        AppServiceErrror: AppServiceError
+    };
+});

--- a/src/client/modules/lib/rpc.js
+++ b/src/client/modules/lib/rpc.js
@@ -28,13 +28,13 @@ define([
         }
 
         call(moduleName, functionName, params) {
-            let override = this.runtime.config(['services', moduleName, 'url'].join('.'));
+            let serviceUrl = this.runtime.config(['services', moduleName, 'url'].join('.'));
             let token = this.runtime.service('session').getAuthToken();
             let client;
-            if (override) {
+            if (serviceUrl) {
                 client = new GenericClient({
                     module: moduleName,
-                    url: override,
+                    url: serviceUrl,
                     token: token
                 });
             } else {
@@ -68,5 +68,61 @@ define([
                 });
         }
     }
-    return RPC;
+
+    class RPCClient {
+        constructor(config) {
+            this.runtime = config.runtime;
+            this.moduleName = config.module;
+            this.RPCError = RPCError;
+            // Note: setup must be synchronous
+            this.setup();
+        }
+
+        setup() {
+            let serviceUrl = this.runtime.config(['services', this.moduleName, 'url'].join('.'));
+            let token = this.runtime.service('session').getAuthToken();
+            let client;
+            if (serviceUrl) {
+                client = new GenericClient({
+                    module: this.moduleName,
+                    url: serviceUrl,
+                    token: token
+                });
+            } else {
+                client = new DynamicService({
+                    url: this.runtime.config('services.service_wizard.url'),
+                    token: token,
+                    module: this.moduleName
+                });
+            }
+            this.client = client;
+        }
+
+        callFunc(functionName, params) {            
+            let funcParams = params || [];
+            return this.client.callFunc(functionName, funcParams)
+                .catch((err) => {
+                    if (err instanceof exceptions.AjaxError) {
+                        console.error('AJAX Error', err);
+                        throw new RPCError('AJAX Error: ' + err.name, err.code, err.message, null, {
+                            originalError: err
+                        });
+                    } else if (err instanceof RPCError) {
+                        console.error('RPC Error', err);
+                        let message = 'An error was encountered running an rpc method';
+                        let detail = 'The module is "' + err.module + '", the method "' + err.func + '", ' +
+                                    'the error returned from the service is "' + (err.message || 'unknown') + '"';
+                        throw new RPCError('service-call-error', err.name, message, detail , {
+                            originalError: err
+                        });
+                    } else {
+                        throw new RPCError('rpc-call', err.name, err.message, null, {
+                            originalError: err
+                        });
+                    }
+                });
+        }
+    }
+
+    return {RPC, RPCClient};
 });

--- a/src/plugins/mainwindow/modules/systemAlertBanner.js
+++ b/src/plugins/mainwindow/modules/systemAlertBanner.js
@@ -1,14 +1,12 @@
 define([
     'knockout',
     'kb_common/html',
-    'lib/rpc',
     'kb_lib/poller',
     './components/systemAlertBanner',
     'bootstrap'
 ], function (
     ko,
     html,
-    RPC,
     poller,
     SystemAlertBannerComponent
 ) {
@@ -23,11 +21,11 @@ define([
         let newAlertsPoller;
 
         function getActiveAlerts() {
-            let rpc = new RPC({
-                runtime: runtime
+            let client = new runtime.service('rpc').makeClient({
+                module: 'UIService'
             });
 
-            return rpc.call('UIService', 'get_active_alerts', [])
+            return client.callFunc('get_active_alerts', [])
                 .spread((result) => {
                     return result;
                 });

--- a/src/plugins/narrativemanager/modules/createNewPanel.js
+++ b/src/plugins/narrativemanager/modules/createNewPanel.js
@@ -1,5 +1,3 @@
-/*global define*/
-/*jslint white:true*/
 define([
     'bluebird',
     'kb_common/html',
@@ -12,6 +10,11 @@ define([
     NarrativeManagerService
 ) {
     'use strict';
+
+    var t = html.tag,
+        div = t('div'),
+        a = t('a'),
+        p = t('p');
 
     function factory(config) {
         var mount, container, runtime = config.runtime,
@@ -58,10 +61,10 @@ define([
                 }
 
                 return narrativeManager.createTempNarrative({
-                        cells: cells,
-                        parameters: appData,
-                        importData: importData
-                    })
+                    cells: cells,
+                    parameters: appData,
+                    importData: importData
+                })
                     .then(function (info) {
                         var wsId = info.narrativeInfo.wsid,
                             objId = info.narrativeInfo.id,
@@ -77,7 +80,6 @@ define([
         }
 
         function wrapPanel(content) {
-            var div = html.tag('div');
             return div({ class: 'container-fluid' }, [
                 div({ class: 'row' }, [
                     div({ class: 'col-md-12' }, [
@@ -86,8 +88,6 @@ define([
                 ])
             ]);
         }
-
-
 
         // API
 
@@ -98,9 +98,6 @@ define([
         }
 
         function start(params) {
-            var div = html.tag('div'),
-                a = html.tag('a'),
-                p = html.tag('p');
             container.innerHTML = wrapPanel(html.loading('Creating a new Narrative for you...'));
             return new Promise(function (resolve, reject) {
                 createNewNarrative(params)

--- a/src/plugins/narrativemanager/modules/narrativeManager.js
+++ b/src/plugins/narrativemanager/modules/narrativeManager.js
@@ -1,5 +1,3 @@
-/*global define*/
-/*jslint white: true*/
 define([
     'bluebird',
     'kb_service/utils',
@@ -29,8 +27,8 @@ define([
         function getMostRecentNarrative() {
             // get the full list of workspaces
             return workspaceClient.callFunc('list_workspace_info', [{
-                    owners: [runtime.service('session').getUsername()]
-                }])
+                owners: [runtime.service('session').getUsername()]
+            }])
                 .spread(function (wsList) {
                     var workspaces = wsList
                         .map(function (workspaceInfo) {
@@ -60,10 +58,10 @@ define([
                         ref = [workspaceInfo.id, workspaceInfo.metadata.narrative].join('/');
 
                     return workspaceClient.callFunc('get_object_info_new', [{
-                            objects: [{ ref: ref }],
-                            includeMetadata: 1,
-                            ignoreErrors: 1
-                        }])
+                        objects: [{ ref: ref }],
+                        includeMetadata: 1,
+                        ignoreErrors: 1
+                    }])
                         .spread(function (objList) {
                             return ({
                                 workspaceInfo: workspaceInfo,


### PR DESCRIPTION
Primary change is that the taxonomy landing page widget in the dataview's genome landing page is fixed. Removed the non-functional build-species-tree button, although the underlying functionality is fixed in a a separate set of changes to dataview and the narrative.
Internal improvements to support all json-rpc calls, starting with the system alert widget.