### PR TITLE
 auth2-client and ui support for configurable providers [SCT-1075]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
       "kbase-knockout-extensions-es6": "0.1.4",
       "kbase-common-ts": "0.18.0",
       "kbase-common-js": "2.16.1",
-      "kbase-common-es6": "0.4.0",
+      "kbase-common-es6": "0.5.1",
       "kbase-sdk-clients-js": "0.5.1",
       "kbase-service-clients-js": "3.3.5",
       "kbase-ui-widget": "1.3.0",

--- a/config/app/dev/plugins.yml
+++ b/config/app/dev/plugins.yml
@@ -126,7 +126,7 @@ plugins:
     -
         name: auth2-client
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.3.1
+        version: 1.3.2
         cwd: src/plugin
         source:
             bower: {}

--- a/config/app/dev/plugins.yml
+++ b/config/app/dev/plugins.yml
@@ -126,7 +126,7 @@ plugins:
     -
         name: auth2-client
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.3.0
+        version: 1.3.1
         cwd: src/plugin
         source:
             bower: {}

--- a/config/app/prod/plugins.yml
+++ b/config/app/prod/plugins.yml
@@ -118,7 +118,7 @@ plugins:
     -
         name: auth2-client
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.3.0
+        version: 1.3.1
         cwd: src/plugin
         source:
             bower: {}

--- a/config/app/prod/plugins.yml
+++ b/config/app/prod/plugins.yml
@@ -118,7 +118,7 @@ plugins:
     -
         name: auth2-client
         globalName: kbase-ui-plugin-auth2-client
-        version: 1.3.1
+        version: 1.3.2
         cwd: src/plugin
         source:
             bower: {}

--- a/config/deploy/appdev.env
+++ b/config/deploy/appdev.env
@@ -14,6 +14,8 @@ allow=[]
 
 services_narrative_url=https://appdev.kbase.us
 
+services_auth2_providers=["Google", "Globus"]
+
 
 # services 
 

--- a/config/deploy/ci.env
+++ b/config/deploy/ci.env
@@ -14,6 +14,8 @@ allow=["alpha", "beta"]
 
 services_narrative_url=https://ci.kbase.us
 
+services_auth2_providers=["Google", "Globus", "OrcID"]
+
 # services 
 
 # list of plugins to remove from the runtime even if specified in the build

--- a/config/deploy/dev.env
+++ b/config/deploy/dev.env
@@ -14,6 +14,8 @@ allow=["alpha", "beta"]
 
 services_narrative_url=https://ci.kbase.us
 
+services_auth2_providers=["Google", "Globus", "OrcID"]
+
 # services 
 
 # list of plugins to remove from the runtime even if specified in the build

--- a/config/deploy/next.env
+++ b/config/deploy/next.env
@@ -14,6 +14,8 @@ allow=[]
 
 services_narrative_url=https://next.kbase.us
 
+services_auth2_providers=["Google", "Globus"]
+
 # services 
 
 # list of plugins to remove from the runtime even if specified in the build

--- a/config/deploy/prod.env
+++ b/config/deploy/prod.env
@@ -14,6 +14,8 @@ allow=[]
 
 services_narrative_url=https://narrative.kbase.us
 
+services_auth2_providers=["Google", "Globus"]
+
 # services 
 
 # list of plugins to remove from the runtime even if specified in the build

--- a/config/services.yml
+++ b/config/services.yml
@@ -20,7 +20,9 @@ services:
         version: 
             path: /
             propertyPath: version
-            minimum: 0.2.5
+            minimum: 0.2.0
+        # configure per deploy environment
+        providers: []
     awe:
         url: '{{ deploy.services.urlBase }}/services/awe-api'
         name: AWE

--- a/deployment/ci/docker/kb-deployment/conf/config.json.tmpl
+++ b/deployment/ci/docker/kb-deployment/conf/config.json.tmpl
@@ -40,6 +40,9 @@
     "services": {
         "narrative": {
             "url": "{{ .Env.services_narrative_url }}"
+        },
+        "auth2": {
+            "providers": {{ default .Env.services_auth2_providers "null" }}
         }
     }
 }

--- a/docs/dev/prerequisites.md
+++ b/docs/dev/prerequisites.md
@@ -8,7 +8,7 @@ The developer setup provides a workflow and set of tools to help develop kbase-u
 
 | app | version | notes |
 |-----|---------|------ |
-| nodejs | 8 (LTS) | The V8 javascript system, required for building kbase-ui and running tests; we are currently on version 8. |
+| nodejs | 6 (LTS) | The V8 javascript system, required for building kbase-ui and running tests; we are currently on version 8. |
 | git    | ?? | the source revision management tool with integration into github |
 | docker | ?? | the linux container manager you will use to run kbase-ui |
 | make  | ?? | all build tasks go through make |
@@ -20,11 +20,11 @@ The developer setup provides a workflow and set of tools to help develop kbase-u
 
 The KBase UI should build and run on any modern system: Mac OS X, Linux, Windows.
 
-Procecedures for installation of system level packages depends on ... the system you use! Even within a platform there may be multiple ways to install a given package. In this document we provide instructions for installation on platforms in use at KBase using methods that we have employed and work.
+Procedures for installation of system level packages depends on ... the system you use! Even within a platform there may be multiple ways to install a given package. In this document we provide instructions for installation on platforms in use at KBase using methods that we have employed and work.
 
 | app    | version | notes                                                        |
 | ------ | ------- | ------------------------------------------------------------ |
-| nodejs | 8 (LTS) | The V8 javascript system, required for building kbase-ui and running tests; we are currently on version 8. |
+| nodejs | 6 (LTS) | The V8 javascript system, required for building kbase-ui and running tests; we are currently on version 8. |
 | git    | ??      | the source revision management tool with integration into github |
 | docker | ??      | the linux container manager you will use to run kbase-ui     |
 | make   | ??      | all build tasks go through make                              |
@@ -50,11 +50,11 @@ There are three common sources for these tools natively on a Mac:
 
 (see the Linux section for Vagrant on Mac instructions.)
 
-The requisite development tools are available as regualar Mac packages. This is may be the easiest way to get started. However, if you are going to be installing other Unixy tools, or have one of the following package managers installed, either Macports or Homebrew may be preferable, and are not much more difficult. Package managers also make updating your tools easy, whereas the downloadable packages will need to be periodically updated manually.
+The requisite development tools are available as regular Mac packages. This is may be the easiest way to get started. However, if you are going to be installing other Unixy tools, or have one of the following package managers installed, either Macports or Homebrew may be preferable, and are not much more difficult. Package managers also make updating your tools easy, whereas the downloadable packages will need to be periodically updated manually.
 
 #### Apple xCode
 
-xCode may be installed from the Apple App Store for free, and is highly recommeded for any developer workstation. Not only does it provide some of the required tools, but some macOS developer tools require xCode be installed.
+xCode may be installed from the Apple App Store for free, and is highly recommended for any developer workstation. Not only does it provide some of the required tools, but some macOS developer tools require xCode be installed.
 
 xCode includes both git and make, which are required for building kbase-ui, as well as a compilers which may be required to install other developer tools via installers from macports, npm, and the like.
 
@@ -116,7 +116,7 @@ open Terminal and issue the following commands:
 sudo port install nodejs6 npm5 git
 ```
 
-Note that the version of nodejs is important. We try very hard to use the same version of nodejs in local development as KBase uses in build/deployment environments and as the Travis configuration uses. There are major changes between nodejs releases. Although a newer nodejs will be probably be able to run code written for an older version, the converse is not necessarily true, and it is certainly easy to start using features enabled by a newer node version if it is available. There may also be subtle differences in the building of dependncies through npm.
+Note that the version of nodejs is important. We try very hard to use the same version of nodejs in local development as KBase uses in build/deployment environments and as the Travis configuration uses. There are major changes between nodejs releases. Although a newer nodejs will be probably be able to run code written for an older version, the converse is not necessarily true, and it is certainly easy to start using features enabled by a newer node version if it is available. There may also be subtle differences in the building of dependencies through npm.
 
 In general we try to stay on the most recent Long Term Support (LTS) of any dependency, but sometimes it takes us a while to have time to coordinate the concurrent update of all of the places they are used.
 

--- a/tools/run-image.sh
+++ b/tools/run-image.sh
@@ -113,7 +113,7 @@ echo "MOUNTS: $mounts"
 
 image_tag="${branch}"
 
-echo "stdout sent to kbase-ui.stoud, stderr sent to kbase-ui.stderr"
+echo "stdout sent to kbase-ui.stdout, stderr sent to kbase-ui.stderr"
 echo "Running kbase-ui image kbase/kbase-ui:${image_tag}"
 echo ":)"
 


### PR DESCRIPTION
- auth2 requirement reduced to 2.0. Note that the OrcID support, although configurable in the admin tool, is only enabled in the 2.5 release. It only makes sense to enable ORCiD when we are sure of a 2.5 auth2 release, but ... good enough for now.