### PR TITLE
remove node 8 prerequisite from makefile and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,14 +79,6 @@ default:
 	@echo Use "make init && make config=TARGET build"
 	@echo see docs/quick-deploy.md
 
-NODE=$(shell node --version 2> /dev/null)
-NODE_REQUIRED="v8"
-majorver=$(word 1, $(subst ., ,$1))
-
-preconditions:
-	@echo "> Testing for preconditions."
-	@echo $(if $(findstring $(call majorver, $(NODE)), $(NODE_REQUIRED)), "Good node version ($(NODE))", $(error "! Node major version must be $(NODE_REQUIRED), it is $(NODE).") )
-
 # Initialization here pulls in all dependencies from Bower and NPM.
 # This is **REQUIRED** before any build process can proceed.
 # bower install is not part of the build process, since the bower
@@ -100,13 +92,13 @@ node_modules:
 	@echo "> Installing build and test tools."
 	npm install
 
-setup: preconditions setup-dirs
+setup: setup-dirs
 
 init: setup node_modules
 
 # Perform the build. Build scnearios are supported through the config option
 # which is passed in like "make build config=ci"
-build: clean-build
+build: clean-build 
 	@echo "> Building."
 	cd mutations; node build $(config)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Most KBase users will be exposed to the KBase UI by ... [using KBase](https://na
 ## Documentation
 
 - [develop](https://ci.kbase.us/_book/index.html) - Documentation available in the current develop branch of kbase-ui
-- [release]() - Documentation available in the current production release (will be available after the 1.7.0 is released)
+- [release](https://narrative.kbase.us/_book/index.html) - Documentation available in the current production release (will be available after the 1.7.0 is released)
 
 ## Contributing
 

--- a/docs/book/getting-started/prerequisites.md
+++ b/docs/book/getting-started/prerequisites.md
@@ -16,15 +16,15 @@ You will need to ensure that you have a basic set of the following tools on your
 
 | app | version | notes |
 |-----|---------|------ |
-| make | >= 3.8 | any relatively recent make should work |
+| docker | 18.x.x | the linux container manager you will use to build and run kbase-ui |
 | git    | * | the source revision management tool with integration into github |
-| docker | 18.x.x | the linux container manager you will use to run kbase-ui |
+| make | >= 3.8 | any relatively recent make should work |
+| node | >= 8 | any recent version should work |
+
 
 > \* we haven't documented any substantial differences between these tools regarding the kbase-ui development process. However, it is best to keep them always at the most recent version by updating your tool stack periodically.
 
-You may have noticed that there are no Javascript tools above, such as nodejs or npm, or development tools such as make. This is because kbase-ui is built inside of a Docker build process, using build tools installed into a Docker image.
-
-It is certainly possible to build kbase-ui locally on your host machine, and this is described in the [Development](../development/README.md) documentation. However, for normal deployment and development, this should not be necessary.
+The reason for the relaxed version requirements is that kbase-ui is built inside of a Docker build process, using specific software package versions which are installed into a Docker image. The software requirements specified above are for local development tools only.
 
 ## macOS
 


### PR DESCRIPTION
- first of a set of files to fix existing docs and extend developer workflow docs