### PR TITLE
user profile - fix affiliations editor and display

### DIFF
--- a/config/app/dev/plugins.yml
+++ b/config/app/dev/plugins.yml
@@ -105,13 +105,13 @@ plugins:
       bower: {}
   - name: auth2-client
     globalName: kbase-ui-plugin-auth2-client
-    version: 1.3.10
+    version: 1.3.11
     cwd: src/plugin
     source:
       bower: {}
   - name: user-profile
     globalName: kbase-ui-plugin-user-profile
-    version: 1.5.1
+    version: 1.5.2
     cwd: src/plugin
     source:
       bower: {}

--- a/config/app/prod/plugins.yml
+++ b/config/app/prod/plugins.yml
@@ -98,13 +98,13 @@ plugins:
       bower: {}
   - name: auth2-client
     globalName: kbase-ui-plugin-auth2-client
-    version: 1.3.10
+    version: 1.3.11
     cwd: src/plugin
     source:
       bower: {}
   - name: user-profile
     globalName: kbase-ui-plugin-user-profile
-    version: 1.5.1
+    version: 1.5.2
     cwd: src/plugin
     source:
       bower: {}


### PR DESCRIPTION
- the affiliations part of the profile editor did not enforce subfield validation
- this let through affiliations with empty fields
- this caused the profile display to fail (console error, no obvious error on page, but some info missing.)
- so fixed the display to be tolerant of such missing fields, and the editor to enforce them.