### PR TITLE
Update search config to use the searchapi2 legacy endpoint.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -97,7 +97,7 @@ services:
         name: Data Import Export
     KBaseSearchEngine:
         aliases: ["search"]
-        url: "{{ deploy.services.urlBase }}/services/searchapi"
+        url: "{{ deploy.services.urlBase }}/services/searchapi2/legacy"
         name: KBase Search Engine
         coreService: true
         type: jsonrpc


### PR DESCRIPTION
This is a pr for `develop` to be deployed in CI in conjunction with this other PR (pending feedback): https://github.com/kbase/kbase-ui-plugin-data-search

Using api found at http://ci.kbase.us/services/searchapi2/legacy