### PR TITLE
auth2-client: just use Arial

### DIFF
--- a/config/plugins.yml
+++ b/config/plugins.yml
@@ -25,7 +25,7 @@ plugins:
       bower: {}
   - name: auth2-client
     globalName: kbase-ui-plugin-auth2-client
-    version: 2.3.14
+    version: 2.3.15
     source:
       bower: {}
   - name: jgi-search


### PR DESCRIPTION
- alignment issues with Oxygen
- other popular web fonts just don't look great