### PR TITLE
Update all plugins to current versions.

### DIFF
--- a/config/plugins.yml
+++ b/config/plugins.yml
@@ -16,7 +16,7 @@ plugins:
         account: kbase
   - name: dataview
     globalName: kbase-ui-plugin-dataview
-    version: 4.7.36
+    version: 4.8.4
     source:
       github:
         account: kbase
@@ -50,21 +50,15 @@ plugins:
     source:
       github:
         account: kbase
-  - name: data-search-20
-    globalName: kbase-ui-plugin-data-search
-    version: 2.0.1
-    source:
-      github:
-        account: kbase
   - name: data-search
     globalName: kbase-ui-plugin-data-search
-    version: 2.1.3
+    version: 2.3.2
     source:
       github:
         account: kbase
   - name: organizations
     globalName: kbase-ui-plugin-organizations
-    version: 2.1.8
+    version: 2.1.9
     source:
       github:
         account: kbase
@@ -76,7 +70,7 @@ plugins:
         account: kbase
   - name: job-browser2
     globalName: kbase-ui-plugin-job-browser2
-    version: 1.6.1
+    version: 1.6.3
     source:
       github:
         account: kbase
@@ -94,13 +88,13 @@ plugins:
         account: eapearson
   - name: samples
     globalName: kbase-ui-plugin-samples
-    version: 0.9.11
+    version: 0.12.14
     source:
       github:
         account: kbaseIncubator
   - name: ontology
     globalName: kbase-ui-plugin-ontology
-    version: 0.2.9
+    version: 0.4.5
     source:
       github:
         account: kbaseIncubator
@@ -112,7 +106,7 @@ plugins:
         account: kbaseIncubator
   - name: public-search
     globalName: kbase-ui-plugin-public-search
-    version: 0.15.4
+    version: 0.16.0
     source:
       github:
         account: eapearson

--- a/tools/js/build-docker-compose-override.js
+++ b/tools/js/build-docker-compose-override.js
@@ -221,7 +221,7 @@ function main(args) {
     mergeLocalTests(root, config, args);
 
     const outputPath = [root, 'dev', 'docker-compose.override.yml'].join('/');
-    fs.writeFileSync(outputPath, yaml.safeDump(config));
+    fs.writeFileSync(outputPath, yaml.dump(config));
 }
 
 main(yargs.parse(process.argv.slice(2)));


### PR DESCRIPTION
This brings this somewhat older version of kbase-ui up-to-date with plugins.
Other than the kbase-ui improvements of the last few months, which are minimal, this is an up-to-date ui.