### PR TITLE
Fix KBASE-4876

### DIFF
--- a/config/plugins.yml
+++ b/config/plugins.yml
@@ -9,7 +9,7 @@ plugins:
               account: kbase
     - name: dataview
       globalName: kbase-ui-plugin-dataview
-      version: 4.9.3
+      version: 4.9.4
       source:
           github:
               account: kbase

--- a/release-notes/RELEASE_NOTES_NEXT.md
+++ b/release-notes/RELEASE_NOTES_NEXT.md
@@ -22,7 +22,7 @@ none
 
 ### FIXES
 
-none
+- KBASE-4876: copy button appears for non-authenticated dataview landing page; now it doesn't
 
 ### MAJOR DEPENDENCY CHANGES
 


### PR DESCRIPTION
simple change to dataview landing page to prevent the Copy button from appearing for unauthenticated views.