### PR TITLE
organizations:  Add DOMPurify to sanitize markup.

### DIFF
--- a/config/plugins.yml
+++ b/config/plugins.yml
@@ -45,7 +45,7 @@ plugins:
               account: kbase
     - name: organizations
       globalName: kbase-ui-plugin-organizations
-      version: 2.1.11
+      version: 2.1.12
       source:
           github:
               account: kbase


### PR DESCRIPTION
# Update organizations to 2.1.12

## Description

Typically `dangerouslySetInnerHTML` is to be avoided, but by using `Marked` we need it. Before this PR, the HTML resulting from `Marked` is too permissive, so this PR introduces `DOMPurify` to sanitize it before rendering it for the user. This makes `DOMPurify` a new dependency for the organizations plugin.

## Testing Instructions

Test by attempting to put unsafe markup into an organization description. Any unsafe markup should not render.  

## Dev Checklist

* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Integration tests have been run and fully pass (only when preparing a release)
* [x] I have run run the code quality script against the codebase (also done implicitly during a build)