### PR TITLE
fix release tag validation [UIP-9]

### DIFF
--- a/.github/workflows/reusable_validate-release-tag.yml
+++ b/.github/workflows/reusable_validate-release-tag.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           script: |
             const releaseTag = '${{ inputs.release_tag }}';
-            if (!/v^[0-9]+\.[0-9]+\.[0-9]+$/.test(releaseTag)) {
+            if (!/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(releaseTag)) {
               core.setFailed(`Release version must follow semantic version naming prefixed with a "v" (e.g. v1.2.3) but is "${releaseTag}"`)
             }


### PR DESCRIPTION
# Pull Request in support of release 2.6.4 [UIP-9]


## Description

This PR just fixes a typo in the release version validation GHA step

## Issues Resolved

https://kbase-jira.atlassian.net/browse/UIP-9

* [x] Added the Jira Tickets to the title of the PR e.g. (PTV-XXX fixes a terrible bug)
* [-] Added the Github Issue to the title of the PR e.g. (PTV-XXX adds an awesome feature)


## Testing Instructions
  
* [x] Tests pass locally
* [x] Tests pass in github actions
* [x] Manually verified that changes area available (by spinning up an instance and navigating to _X_ to see _Y_)

## Dev Checklist

* [-] Code follows the guidelines at [https://sites.google.com/truss.works/kbasetruss/development](https://sites.google.com/truss.works/kbasetruss/development)
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [-] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Integration tests have been run and fully pass (only when preparing a release)
* [x] I have run run the code quality script against the codebase (also done implicitly during a build)

## Release Notes

* [x] Ensure there is an "upcoming release notes" file located in release-notes/RELEASE_NOTES_NEXT.md
* [x] Add relevant notes to this document

## Release

* x ] Bump version in config/release.yml
* [x] Rename release-notes/RELEASE_NOTES_NEXT.md to the appropriate release
* [x] Add release notes document to the release notes index release-notes/index.md


[UIP-9]: https://kbase-jira.atlassian.net/browse/UIP-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ