### PR TITLE
UIP-35 Update to use anonymous user ids for Google Analytics call

### DIFF
--- a/release-notes/RELEASE_NOTES_NEXT.md
+++ b/release-notes/RELEASE_NOTES_NEXT.md
@@ -1,6 +1,6 @@
 # KBase kbase-ui NEXT Release Notes
 
-none
+The main change here is to update the call to Google Analytics to anonymize the user id sent.
 
 ## CHANGES
 
@@ -18,7 +18,7 @@ none
 
 ### IMPROVEMENTS
 
-none
+- UIP-35: sends an anonymous id to Google Analytics instead of a user name
 
 ### FIXES
 

--- a/src/client/js/gtagSupport.js
+++ b/src/client/js/gtagSupport.js
@@ -319,7 +319,7 @@ function main() {
 
         const auth = await getAuth();
         if (auth) {
-            pageView.user_id = auth.user;
+            pageView.user_id = auth.anonid;
         }
 
         pushGTag('event', 'page_view', pageView);


### PR DESCRIPTION
# Pull Request

## Description

This updates the call to set up Google Analytics to use the shiny new `anonid` key provided by the `/me` endpoint of the auth service. This turns a KBase user id, which Google might perceive as PII, into an anonymous string unique to each user.

Note that this sorta depends on Auth2 v0.6.0 being released in production, otherwise `null` gets sent. Which isn't a terrible thing, but not the desired outcome.

## Issues Resolved

Resolves https://kbase-jira.atlassian.net/browse/UIP-35

* [x] Added the Jira Tickets to the title of the PR e.g. (PTV-XXX fixes a terrible bug)
~~* [ ] Added the Github Issue to the title of the PR e.g. (PTV-XXX adds an awesome feature)~~

> Provide details for testing status and how to test the PR:
  
* [x] Tests pass locally
* [ ] Tests pass in github actions
* [x] Manually verified that changes area available (by spinning up an instance and navigating to _X_ to see _Y_)

## Dev Checklist

* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new browser console messages
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] I have run run the code quality script (`make quality`) against the codebase 

## Release Notes

* [x] Ensure there is an "upcoming release notes" file located in release-notes/RELEASE_NOTES_NEXT.md
* [x] Add relevant notes to this document
